### PR TITLE
Add uglify-save-license

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,7 +35,8 @@
     "http-proxy": "~1.1.4",
     "phantomjs": "~1.9.7-8",
     "protractor": "~0.24.0",
-    "gulp-protractor": "0.0.7"
+    "gulp-protractor": "0.0.7",
+    "uglify-save-license": "^0.4.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -3,6 +3,7 @@
 var gulp = require('gulp');
 
 var $ = require('gulp-load-plugins')();
+var saveLicense = require('uglify-save-license');
 
 gulp.task('styles', function () {
   return gulp.src('app/styles/main.scss')
@@ -49,7 +50,7 @@ gulp.task('html', ['styles', 'scripts', 'partials'], function () {
     .pipe($.rev())
     .pipe(jsFilter)
     .pipe($.ngmin())
-    .pipe($.uglify())
+    .pipe($.uglify({preserveComments: saveLicense}))
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
     .pipe($.replace('bower_components/bootstrap-sass-official/vendor/assets/fonts/bootstrap','fonts'))

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -36,7 +36,8 @@
     "gulp-order": "~1.0.6",
     "phantomjs": "~1.9.7-8",
     "protractor": "~0.24.0",
-    "gulp-protractor": "0.0.7"
+    "gulp-protractor": "0.0.7",
+    "uglify-save-license": "^0.4.1"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
[uglify-save-license](https://github.com/shinnn/uglify-save-license) is an UglifyJS helper to detect and preserve license comments.
Even if the license statement is in multiple line comments, or the comment has no directive such as `@license` and `/*!`, this module keeps them readable.
