### PR TITLE
Fix singlequote warning in `__uirouter.js` template

### DIFF
--- a/app/templates/app/scripts/__uirouter.js
+++ b/app/templates/app/scripts/__uirouter.js
@@ -2,7 +2,7 @@
   .config(function ($stateProvider, $urlRouterProvider) {
     $stateProvider
       .state('home', {
-        url: "/",
+        url: '/',
         templateUrl: 'partials/main.html',
         controller: 'MainCtrl'
       });


### PR DESCRIPTION
JSHint reports "Strings must use singlequote." against any file using the `__uirouter.js` template
