### PR TITLE
Improve middleware with a better static file filter.

### DIFF
--- a/app/templates/gulp/server.js
+++ b/app/templates/gulp/server.js
@@ -12,10 +12,10 @@ var proxy = httpProxy.createProxyServer({
   target: proxyTarget
 });
 
-/* proxyMiddleware forwards static files to BrowserSync server
+/* proxyMiddleware forwards static file requests to BrowserSync server
    and forwards dynamic requests to your real backend */
 function proxyMiddleware(req, res, next) {
-  if (/\.(html|png|css|jpg|jpeg|gif|js|ico|xml|rss|txt)(\?(r|v|rel|rev)=[\-\.\w]*)?$/.test(req.url)) {
+  if (/\.(html|css|js|png|jpg|jpeg|gif|ico|xml|rss|txt|eot|svg|ttf|woff)(\?((r|v|rel|rev)=[\-\.\w]*)?)?$/.test(req.url)) {
     next();
   } else {
     proxy.web(req, res);


### PR DESCRIPTION
Hi, 

I just added a better static file filter for middleware, it basically filter out static files ending with `html|png|css|jpg|jpeg|gif|js|ico|xml|rss|txt`, with or without revision query params (example: `script.js?v=h4s1-l`). This is inspired by a typical nginx server config file, and modified to support revision params. Stumbled upon this because the original dynamic request filter config didn't work with my backend. 

Although this file should be changed frequently based on user's backend but I think this is general enough to support most server config.

Cheers!
Marani.
