### PR TITLE
Ensure module sorting, closes #162

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,6 +6,7 @@
     "gulp": "~3.8.10",
     "gulp-autoprefixer": "~2.0.0",
     "gulp-cache": "~0.2.4",
+    "gulp-angular-filesort": "~1.0.4",
     "gulp-angular-templatecache": "~1.4.2",
     "del": "~0.1.3",
     "gulp-csso": "~0.2.9",

--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -84,7 +84,7 @@ gulp.task('injector:js', ['jshint', 'injector:css'], function () {
         'src/{app,components}/**/*.js',
         '!src/{app,components}/**/*.spec.js',
         '!src/{app,components}/**/*.mock.js'
-      ], {read: false}), {
+      ]).pipe($.angularFilesort()), {
       ignorePath: 'src',
       addRootSlash: false
     }))

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -6,6 +6,7 @@
     "gulp": "~3.8.10",
     "gulp-autoprefixer": "~2.0.0",
     "gulp-cache": "~0.2.4",
+    "gulp-angular-filesort": "~1.0.4",
     "gulp-angular-templatecache": "~1.4.2",
     "del": "~0.1.3",
     "gulp-csso": "~0.2.9",


### PR DESCRIPTION
Note, `{read: false}` needed to be omitted so that gulp-angular-filesort could
read each file's contents, see:
https://github.com/klei/gulp-angular-filesort/pull/14
