### PR TITLE
Sorts source modules in unit tests, closes #188

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -32,6 +32,7 @@
     "gulp-angular-filesort": "~1.0.4",<% } if(props.jsPreprocessor.key === 'coffee') { %>
     "gulp-coffeelint": "~0.4.0",<% } %>
     "main-bower-files": "~2.4.0",
+    "merge-stream": "~0.1.6",
     "jshint-stylish": "~1.0.0",
     "wiredep": "~2.2.0",
     "karma-jasmine": "~0.3.1",

--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -4,6 +4,7 @@ var gulp = require('gulp');
 
 var $ = require('gulp-load-plugins')();
 
+var merge = require('merge-stream');
 var wiredep = require('wiredep');
 
 function runTests (singleRun, done) {
@@ -14,7 +15,8 @@ function runTests (singleRun, done) {
     devDependencies: true
   });
 
-  var testFiles = bowerDeps.js.concat([ <% if (props.jsPreprocessor.key === 'none') { %>
+  var testFiles = gulp.src(bowerDeps.js);
+  var srcFiles = gulp.src([ <% if (props.jsPreprocessor.key === 'none') { %>
     'src/{app,components}/**/*.js' <%
   } else if (props.jsPreprocessor.extension === 'js') { %>
     '.tmp/app/index.js',
@@ -30,9 +32,9 @@ function runTests (singleRun, done) {
     'src/{app,components}/**/*.spec.js',
     'src/{app,components}/**/*.mock.js' <%
   } %>
-  ]);
+  ]).pipe($.angularFilesort());
 
-  gulp.src(testFiles)
+  merge(testFiles, srcFiles)
     .pipe($.karma({
       configFile: 'karma.conf.js',
       action: (singleRun)? 'run': 'watch'

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -28,6 +28,7 @@
     "gulp-protractor": "~0.0.11",
     "gulp-karma": "~0.0.4",
     "main-bower-files": "~2.4.0",
+    "merge-stream": "~0.1.6",
     "jshint-stylish": "~1.0.0",
     "wiredep": "~2.2.0",
     "karma-jasmine": "~0.3.1",


### PR DESCRIPTION
Splits the wiredep-managed test files and source files stream, sorts the source
files via gulp-angular-filesort and merges them back together for use in Karma.