### PR TITLE
more cleaner way to setup srcTemplates and staticFiles

### DIFF
--- a/app/files.json
+++ b/app/files.json
@@ -27,9 +27,10 @@
     "gulp/wiredep.js",
     "gulp/server.js",
     "gulp/unit-tests.js",
-
+    "src/app/index.js",
     "src/index.html",
-
-    "src/app/main/main.controller.spec.js"
+    "src/app/main/main.controller.js",
+    "src/app/main/main.controller.spec.js",
+    "src/components/navbar/navbar.controller.js"
   ]
 }

--- a/app/src/format.js
+++ b/app/src/format.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var path = require('path');
+var files = require('../files.json');
+var fs = require('fs');
 
 module.exports = function () {
   var _ = this._;
@@ -155,18 +157,39 @@ module.exports = function () {
   }
 
   //JS Preprocessor files
-  var files = [
-    'src/app/index',
-    'src/app/main/main.controller',
-    'src/components/navbar/navbar.controller'
-  ];
-
   this.srcTemplates = {};
-  files.forEach(function(file) {
+  files.templates.forEach(function(file) {
     var basename = path.basename(file);
-    var dest = file + '.' + this.props.jsPreprocessor.extension;
-    var src = file.replace(basename, '_' + basename) + '.' + this.props.jsPreprocessor.srcExtension;
+    var src = file.replace(basename, '_' + basename);
+    var dest = file;
+
+    var isJsPreprocessor = src.match(/\.js$/) && fs.existsSync(this.sourceRoot() + '/' + src.replace(/\.js$/, '.' + this.props.jsPreprocessor.srcExtension));
+
+    if(isJsPreprocessor) {
+      src = src.replace(/\.js$/, '.' + this.props.jsPreprocessor.srcExtension);
+    }
+    if(isJsPreprocessor) {
+      dest = dest.replace(/\.js$/, '.' + this.props.jsPreprocessor.extension);
+    }
+
     this.srcTemplates[src] = dest;
+  }, this);
+
+  this.staticFiles = {};
+  files.staticFiles.forEach(function(file) {
+    var src = file;
+    var dest = file;
+
+    var isJsPreprocessor = src.match(/\.js$/) && fs.existsSync(this.sourceRoot() + '/' + src.replace(/\.js$/, '.' + this.props.jsPreprocessor.srcExtension));
+
+    if(isJsPreprocessor) {
+      src = src.replace(/\.js$/, '.' + this.props.jsPreprocessor.srcExtension);
+    }
+    if(isJsPreprocessor) {
+      dest = dest.replace(/\.js$/, '.' + this.props.jsPreprocessor.extension);
+    }
+
+    this.staticFiles[src] = dest;
   }, this);
 
   this.lintConfCopies = [];

--- a/app/src/write.js
+++ b/app/src/write.js
@@ -7,17 +7,15 @@ var path = require('path');
 module.exports = function () {
   var _ = this._;
 
-  // Copy static files
-  _.forEach(files.staticFiles, function(src) {
-    this.fs.copy(this.templatePath(src),  this.destinationPath(src));
-  }.bind(this));
-
   // Copy dot files
   _.forEach(files.dotFiles, function(src) {
     this.fs.copy(this.templatePath(src),  this.destinationPath('.' + src));
   }.bind(this));
 
   // Copy files formatted (format.js) with options selected in prompt
+  _.forEach(this.staticFiles, function(value, key) {
+    this.fs.copy(this.templatePath(key),  this.destinationPath(value));
+  }.bind(this));
   _.forEach(this.technologiesLogoCopies, function(src) {
     this.fs.copy(this.templatePath(src),  this.destinationPath(src));
   }.bind(this));
@@ -32,14 +30,5 @@ module.exports = function () {
   }.bind(this));
   _.forEach(this.lintConfCopies, function(src) {
     this.fs.copy(this.templatePath(src),  this.destinationPath(src));
-  }.bind(this));
-
-  // Create files with templates
-  var basename;
-  var src;
-  _.forEach(files.templates, function(dest) {
-    basename = path.basename(dest);
-    src = dest.replace(basename, '_' + basename);
-    this.fs.copyTpl(this.templatePath(src),  this.destinationPath(dest), this);
   }.bind(this));
 };

--- a/test/test-write-files.js
+++ b/test/test-write-files.js
@@ -13,13 +13,16 @@ describe('gulp-angular generator files', function () {
     var actualTemplate = 0;
 
     files.call({
+      srcTemplates: data.templates,
+      staticFiles: data.staticFiles,
       _: _,
       fs: {
         copy: function() { actualCopy++; },
         copyTpl: function() { actualTemplate++; }
       },
       templatePath: function (string) { return string; },
-      destinationPath: function (string) { return string; }
+      destinationPath: function (string) { return string; },
+      template: function (key, val) { actualTemplate++; }
     });
 
     var expectedCopy =


### PR DESCRIPTION
The jsPreprocessor feature is great.

This pr is intend to make the following improvement:
1. some of the files are listed inside format.js, which I think it's better to mention them in files.json.
1. as the implementation of multiple languages, it's possible that some files are with only few language support.
   this pr relaxes the requirement of implementing with all languages by falling back to .js files.
2. though for now gulp files and other config .js are supported with .js only, I would like to allow them to be supported with multiple languages.
