### PR TITLE
Update Test guideline for CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,23 @@ Because we create a generator you should be specific as possible in your request
 
 Before you submit your pull request consider the following guidelines:
 
+**Test**  
+Please add unit tests for every new feature or bug fix and make sure all tests pass before submitting pull requests. Generator tests are written in [Mocha](http://mochajs.org).  [Karma](http://karma-runner.github.io/0.12/index.html) and [Protractor](http://angular.github.io/protractor) are used to run unit tests and e2e tests on generated app.
+* Run `./node_modules/mocha/bin/_mocha ./test/*.js` to execute all tests instead of `npm test`. Currently all protractor tests in (2) are excluded from `npm test` due to Travis issue. 
+* Add tests into (1) and (2) if there are changes in generated project's structure. 
+* Feel free to create new test file for new generator features. Use `mute.js` to generate nice test reports.
+
+  | Test Files | Functionality 
+  |:-- |:-- 
+  | (1) `test-files-generate.mocha.js` | Test generated app files' content. 
+  | (2) `test-gulp-task-inception.mocha.js` | Test `gulp build`, `gulp protractor` & `gulp test` on generated app. This verifies gulp task logic and dependencies.
+  | (3) `test-options.mocha.js` | Test default options. 
+  | (4) `mute.js` | Mute Yeoman during tests. 
+  | (5) `test-import-gen.js` | Test generator directory. 
+  | (6) `test-write-files.js` | Test number of files in generated app. 
+
 **Style Guide**  
 Please brief yourself on [Idiomatic.js](https://github.com/rwldrn/idiomatic.js) style guide with two space indent.
-
-**Unit test**  
-Unit test are written in [Mocha](http://visionmedia.github.io/mocha/). Please add a unit test for every new feature or bug fix. `npm test` to run the test suite.  
 
 **Documentation**  
 Add documentation for every new feature, directory structure change. Feel free to send corrections or better docs!


### PR DESCRIPTION
To run all the tests, we should use `./node_modules/mocha/bin/_mocha ./test/*.js` instead of `npm test` before each PR. 

This is also a reminder that we are still having test issue on Travis. We should really find a way to make protractor tests run on Travis, perhaps something like Saucelab but I have no experience with it.
