### PR TITLE
Added an in-terminal qr code to gulp:serve

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -41,6 +41,7 @@
     "http-proxy": "~1.7.0",
     "chalk": "~0.5.1",
     "protractor": "~1.4.0",
+    "qrcode-terminal": "~0.9.5",
     "uglify-save-license": "~0.4.1"<% if(npmDevDependencies.length > 0) { %>,<% } %>
     <%= npmDevDependencies.join(',\n    ') %>
   },

--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -6,6 +6,8 @@ var util = require('util');
 
 var browserSync = require('browser-sync');
 
+var qrcode = require('qrcode-terminal');
+
 var middleware = require('./proxy');
 
 function browserSyncInit(baseDir, files, browser) {
@@ -26,6 +28,8 @@ function browserSyncInit(baseDir, files, browser) {
       routes: routes
     },
     browser: browser
+  }, function(err, bs){
+    qrcode.generate(bs.options.urls.external);
   });
 
 }

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -51,7 +51,8 @@
     "gulp-browserify": "~0.5.0",
     "jade": "~1.8.1",
     "hamljs": "~0.6.2",
-    "handlebars": "~2.0.0"
+    "handlebars": "~2.0.0",
+    "qrcode-terminal": "~0.9.5"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
You can scan this with your phone to open your project.

Useful if you're developing on a mobile device. Indispensable if you're developing on several mobile devices and changing wifi networks frequently.

![image](https://cloud.githubusercontent.com/assets/1147390/5544980/a5f568ce-8ada-11e4-8b91-5b779dac12f8.png)