### PR TITLE
Fix bower_components path in less build config

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -10,7 +10,7 @@ gulp.task('styles', ['wiredep', 'injector:css:preprocessor'], function () {<% if
   return gulp.src(['src/app/index.less', 'src/app/vendor.less'])
     .pipe($.less({
       paths: [
-        'src/bower_components',
+        'bower_components',
         'src/app',
         'src/components'
       ]


### PR DESCRIPTION
This directory was first moved in https://github.com/Swiip/generator-gulp-angular/commit/023757188f3018b8627efcad40343d8c0f4e92a0
