### PR TITLE
Fix styles injection for custom stylesheets files

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -40,12 +40,15 @@ gulp.task('styles', function () {
     addRootSlash: false
   };
 
-  var indexFilter = $.filter(paths.src + '/app/index.<%= props.cssPreprocessor.extension %>');
+  var indexFilter = $.filter('index.<%= props.cssPreprocessor.extension %>');
 
   return gulp.src([
     paths.src + '/app/index.<%= props.cssPreprocessor.extension %>',
     paths.src + '/app/vendor.<%= props.cssPreprocessor.extension %>'
   ])
+    .pipe(indexFilter)
+    .pipe($.inject(injectFiles, injectOptions))
+    .pipe(indexFilter.restore())
 <% if (props.cssPreprocessor.key === 'less') { %>
     .pipe($.less())
 <% } else if (props.cssPreprocessor.key === 'ruby-sass') { %>
@@ -55,13 +58,11 @@ gulp.task('styles', function () {
 <% } else if (props.cssPreprocessor.key === 'stylus') { %>
     .pipe($.stylus())
 <% } %>
+
+  .pipe($.autoprefixer())
     .on('error', function handleError(err) {
       console.error(err.toString());
       this.emit('end');
     })
-    .pipe($.autoprefixer())
-    .pipe(indexFilter)
-    .pipe($.inject(injectFiles, injectOptions))
-    .pipe(indexFilter.restore())
     .pipe(gulp.dest(paths.tmp + '/serve/app/'));
 });


### PR DESCRIPTION
There were two problems related to `gulp-filter` to inject only in `index.scss` : 

- Sass compilation must be performed after `index.scss` injection.
- The filter pattern must be filename only `index.scss`, because default basepath of vinyl files is `src/app/`.

Close #222