### PR TITLE
Disable qrcode generation if not choosen

### DIFF
--- a/app/src/format.js
+++ b/app/src/format.js
@@ -30,7 +30,7 @@ module.exports = function () {
   if (this.props.advancedFeatures) {
     this.includeModernizr = (this.props.advancedFeatures.indexOf('modernizr') >= 0);
     this.imageMin = (this.props.advancedFeatures.indexOf('imagemin') >= 0);
-    this.qrCode = (this.props.advancedFeatures.indexOf('qrCode') >= 0);
+    this.qrCode = (this.props.advancedFeatures.indexOf('qrcode') >= 0);
   }
 
   // Format list ngModules included in AngularJS DI

--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -8,9 +8,11 @@ var util = require('util');
 
 var browserSync = require('browser-sync');
 
-var qrcode = require('qrcode-terminal');
-
 var middleware = require('./proxy');
+<% if(qrCode) { %>
+
+var qrcode = require('qrcode-terminal');
+<% } %>
 
 function browserSyncInit(baseDir, files, browser) {
   browser = browser === undefined ? 'default' : browser;
@@ -30,10 +32,13 @@ function browserSyncInit(baseDir, files, browser) {
       routes: routes
     },
     browser: browser
+<% if(qrCode) { %>
   }, function(err, bs) {
     qrcode.generate(bs.options.urls.external);
   });
-
+<% } else { %>
+  });
+<% } %>
 }
 
 gulp.task('serve', ['watch'], function () {


### PR DESCRIPTION
server.js template was not checking `qrCode` variable. It also fix a typo in `format.js` to load qrCode variable properly.

Close #221