### PR TITLE
Fix no html preprocessor

### DIFF
--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 
 var paths = gulp.paths;
 
-<% if (props.htmlPreprocessor.extension === 'none') { %>
+<% if (props.htmlPreprocessor.key === 'none') { %>
 gulp.task('watch', ['inject'], function () {
 <% } else { %>
 gulp.task('watch', ['markups', 'inject'], function () {
@@ -17,7 +17,7 @@ gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
     'bower.json'
   ], ['inject']);
-<% if (props.htmlPreprocessor.extension !== 'none') { %>
+<% if (props.htmlPreprocessor.key !== 'none') { %>
   gulp.watch(paths.src + '/{app,components}/**/*.<%= props.htmlPreprocessor.extension %>', ['markups']);
 <% } %>
 });


### PR DESCRIPTION
In `_watch.js`, there was a test on the wrong property which broke the task when non html preprocessor was chosen.
