### PR TITLE
font-path in html task should be the same as __bootstrap-vendor.scss

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -51,9 +51,9 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
 <% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'scss') { %>
-    .pipe($.replace('<%= computedPaths.appToBower %>/bootstrap-sass-official/assets/fonts/bootstrap', 'fonts'))
+    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap', 'fonts'))
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'less') { %>
-    .pipe($.replace('<%= computedPaths.appToBower %>/bootstrap/fonts', 'fonts'))
+    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap/fonts', 'fonts'))
 <% } %>
     .pipe($.csso())
     .pipe(cssFilter.restore())

--- a/test/test-files-generate.mocha.js
+++ b/test/test-files-generate.mocha.js
@@ -167,7 +167,10 @@ describe('gulp-angular generator', function () {
           ['package.json', libRegexp('gulp-sass', prompts.cssPreprocessor.values['node-sass'].version)],
 
           // Check wiredep css exclusion.
-          ['gulp/inject.js', /exclude:.*?\/bootstrap\\\.css\/.*?/]
+          ['gulp/inject.js', /exclude:.*?\/bootstrap\\\.css\/.*?/],
+
+          // Check font-path replace in html
+          ['gulp/build.js', /\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap/]
         ]));
 
         assert.noFileContent([].concat([


### PR DESCRIPTION
In gulp html,
the task intends to replace the font path in .css but failed when using bootstrap with scss.

This pr intends to fix that.