### PR TITLE
Generate sourcemaps when using a JS Preprocessor

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -32,6 +32,7 @@
     "<%= props.cssPreprocessor.module %>": "<%= props.cssPreprocessor.version %>",
 <% } if (props.jsPreprocessor.key !== 'none') { %>
     "<%= props.jsPreprocessor.module %>": "<%= props.jsPreprocessor.version %>",
+    "gulp-sourcemaps": "~1.3.0",
 <% } if (props.jsPreprocessor.srcExtension === 'es6') { %>
     "gulp-browserify": "~0.5.0",
 <% } else { %>

--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -11,6 +11,8 @@ gulp.task('scripts', function () {
 <% if (props.jsPreprocessor.extension === 'js') { %>
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
+<% } if (props.jsPreprocessor.key !== 'none') { %>
+    .pipe($.sourcemaps.init())
 <% } if (props.jsPreprocessor.key === '6to5') { %>
     .pipe($['6to5']())
 <% } if (props.jsPreprocessor.key === 'traceur') { %>
@@ -21,7 +23,8 @@ gulp.task('scripts', function () {
     .pipe($.coffee())
 <% } if (props.jsPreprocessor.key === 'typescript') { %>
     .pipe($.typescript())
-<% } %>
+<% } if (props.jsPreprocessor.key !== 'none') { %>
+    .pipe($.sourcemaps.write())<% } %>
     .on('error', function handleError(err) {
       console.error(err.toString());
       this.emit('end');

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -49,6 +49,7 @@
     "gulp-6to5": "~1.0.2",
     "gulp-typescript": "~2.3.0",
     "gulp-browserify": "~0.5.0",
+    "gulp-sourcemaps": "~1.3.0",
     "jade": "~1.8.1",
     "hamljs": "~0.6.2",
     "handlebars": "~2.0.0",


### PR DESCRIPTION
Using [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps), which seems to work with every supported JS Processor.