### PR TITLE
fix watch on index.html

### DIFF
--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -58,7 +58,6 @@ gulp.task('serve', ['watch'], function () {
     paths.src + 'src/assets/images/**/*',
     paths.tmp + '/serve/*.html',
     paths.tmp + '/serve/{app,components}/**/*.html',
-    paths.src + '/*.html',
     paths.src + '/{app,components}/**/*.html'
   ]);
 });

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -10,6 +10,7 @@ gulp.task('watch', ['inject'], function () {
 gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
   gulp.watch([
+    paths.src + '/*.html',
     paths.src + '/{app,components}/**/*.<%= props.cssPreprocessor.extension %>',
     paths.src + '/{app,components}/**/*.js',
 <% if (props.jsPreprocessor.extension !== 'js') { %>


### PR DESCRIPTION
With the recent refacto, the index.html is now always a transformed file which has to be watched ans served only from `path.tmp`