### PR TITLE
Don't drop newline when template starts with <%= or <%-

### DIFF
--- a/app/src/write.js
+++ b/app/src/write.js
@@ -9,7 +9,7 @@ module.exports = function () {
   var data = this;
 
   function process(content) {
-    return _.template(content.toString().replace(/\n<%/g, '<%'), data);
+    return _.template(content.toString().replace(/\n<%![-=]]/g, '<%'), data);
   }
 
   var copy = function copy(src, dest, processing) {


### PR DESCRIPTION
This is to avoid breaking `.gitignore` template.

```js
node_modules/
bower_components/
.sass-cache/
<%= props.paths.tmp %>/
<%= props.paths.dist %>/
```

without this change generates the following file

```js
node_modules/
bower_components/
.sass-cache/.tmp/dist/
```

instead of 

```js
node_modules/
bower_components/
.sass-cache/
.tmp/
dist/
```