### PR TITLE
Bootstrap font paths

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -51,9 +51,9 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
 <% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'scss') { %>
-    .pipe($.replace('<%= computedPaths.appToBower %>/bootstrap-sass-official/assets/fonts/bootstrap', 'fonts'))
+    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap', 'fonts'))
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'less') { %>
-    .pipe($.replace('<%= computedPaths.appToBower %>/bootstrap/fonts', 'fonts'))
+    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap/fonts', 'fonts'))
 <% } %>
     .pipe($.csso())
     .pipe(cssFilter.restore())

--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -51,9 +51,9 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
 <% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'scss') { %>
-    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap', 'fonts'))
+    .pipe($.replace('/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/', '../fonts/'))
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'less') { %>
-    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap/fonts', 'fonts'))
+    .pipe($.replace('/bower_components/bootstrap/fonts/', '../fonts/'))
 <% } %>
     .pipe($.csso())
     .pipe(cssFilter.restore())
@@ -83,7 +83,7 @@ gulp.task('images', function () {
 
 gulp.task('fonts', function () {
   return gulp.src($.mainBowerFiles())
-    .pipe($.filter('**/*.{eot,svg,ttf,woff}'))
+    .pipe($.filter('**/*.{eot,svg,ttf,woff,woff2}'))
     .pipe($.flatten())
     .pipe(gulp.dest(paths.dist + '/fonts/'));
 });

--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -58,7 +58,6 @@ gulp.task('serve', ['watch'], function () {
     paths.src + 'src/assets/images/**/*',
     paths.tmp + '/serve/*.html',
     paths.tmp + '/serve/{app,components}/**/*.html',
-    paths.src + '/*.html',
     paths.src + '/{app,components}/**/*.html'
   ]);
 });

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -4,7 +4,7 @@ var gulp = require('gulp');
 
 var paths = gulp.paths;
 
-<% if (props.htmlPreprocessor.extension === 'none') { %>
+<% if (props.htmlPreprocessor.key === 'none') { %>
 gulp.task('watch', ['inject'], function () {
 <% } else { %>
 gulp.task('watch', ['markups', 'inject'], function () {
@@ -17,7 +17,7 @@ gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
     'bower.json'
   ], ['inject']);
-<% if (props.htmlPreprocessor.extension !== 'none') { %>
+<% if (props.htmlPreprocessor.key !== 'none') { %>
   gulp.watch(paths.src + '/{app,components}/**/*.<%= props.htmlPreprocessor.extension %>', ['markups']);
 <% } %>
 });

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -10,6 +10,7 @@ gulp.task('watch', ['inject'], function () {
 gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
   gulp.watch([
+    paths.src + '/*.html',
     paths.src + '/{app,components}/**/*.<%= props.cssPreprocessor.extension %>',
     paths.src + '/{app,components}/**/*.js',
 <% if (props.jsPreprocessor.extension !== 'js') { %>

--- a/app/templates/src/app/__bootstrap-vendor.scss
+++ b/app/templates/src/app/__bootstrap-vendor.scss
@@ -1,3 +1,3 @@
-$icon-font-path: "../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
+$icon-font-path: "/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
 
 @import '../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap';

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Yeoman generator for AngularJS with GulpJS",
   "keywords": "yeoman-generator, angular, gulp",
   "license": "MIT",
-  "author": "Matthieu Lux <matthieu.lux@gmail.com> (https://github.com/Swiip)",
+  "author": "Matthieu Lux & Mehdy Dara",
   "contributors": [
     "Matthieu Lux <matthieu.lux@gmail.com> (https://github.com/Swiip)",
     "Mehdy Dara <mdara@eleven-labs.com> (http://eleven-labs.com/)"

--- a/test/test-files-generate.mocha.js
+++ b/test/test-files-generate.mocha.js
@@ -149,7 +149,7 @@ describe('gulp-angular generator', function () {
           ['src/app/index.js', /'ngRoute'/],
 
           // Check src/app/vendor.scss
-          ['src/app/vendor.scss', /\$icon-font-path: "\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
+          ['src/app/vendor.scss', /\$icon-font-path: "\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
           ['src/app/vendor.scss', /@import '\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/stylesheets\/bootstrap';/],
 
           // Check bower.json
@@ -170,7 +170,7 @@ describe('gulp-angular generator', function () {
           ['gulp/inject.js', /exclude:.*?\/bootstrap\\\.css\/.*?/],
 
           // Check font-path replace in html
-          ['gulp/build.js', /\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap/]
+          ['gulp/build.js', /\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\//]
         ]));
 
         assert.noFileContent([].concat([
@@ -587,7 +587,7 @@ describe('gulp-angular generator', function () {
         ]));
 
         assert.fileContent([].concat(expectedGulpContent, [
-          ['src/app/vendor.scss', /\$icon-font-path: "\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
+          ['src/app/vendor.scss', /\$icon-font-path: "\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
           ['src/app/vendor.scss', /@import '\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/stylesheets\/bootstrap';/],
           ['bower.json', libRegexp('bootstrap-sass-official', prompts.ui.values.bootstrap.version)],
           ['package.json', libRegexp('gulp-ruby-sass', prompts.cssPreprocessor.values['ruby-sass'].version)],
@@ -615,7 +615,7 @@ describe('gulp-angular generator', function () {
         ]));
 
         assert.fileContent([].concat(expectedGulpContent, [
-          ['src/app/vendor.less', /@import '..\/..\/bower_components\/bootstrap\/less\/bootstrap.less';/],
+          ['src/app/vendor.less', /@import '\.\.\/\.\.\/bower_components\/bootstrap\/less\/bootstrap\.less';/],
           ['src/app/vendor.less', /@icon-font-path: '\/bower_components\/bootstrap\/fonts\/';/],
           ['bower.json', libRegexp('bootstrap', prompts.ui.values.bootstrap.version)],
           ['package.json', libRegexp('gulp-less', prompts.cssPreprocessor.values.less.version)],
@@ -1127,7 +1127,7 @@ describe('gulp-angular generator', function () {
           [optionCase['app-path'] + '/app/index.js', /'ngRoute'/],
 
           // Check src/app/vendor.scss
-          [optionCase['app-path'] + '/app/vendor.scss', /\$icon-font-path: "\.\.\/\.\.\/\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
+          [optionCase['app-path'] + '/app/vendor.scss', /\$icon-font-path: "\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
           [optionCase['app-path'] + '/app/vendor.scss', /@import '\.\.\/\.\.\/\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/stylesheets\/bootstrap';/],
 
           // Check bower.json

--- a/test/test-files-generate.mocha.js
+++ b/test/test-files-generate.mocha.js
@@ -167,7 +167,10 @@ describe('gulp-angular generator', function () {
           ['package.json', libRegexp('gulp-sass', prompts.cssPreprocessor.values['node-sass'].version)],
 
           // Check wiredep css exclusion.
-          ['gulp/inject.js', /exclude:.*?\/bootstrap\\\.css\/.*?/]
+          ['gulp/inject.js', /exclude:.*?\/bootstrap\\\.css\/.*?/],
+
+          // Check font-path replace in html
+          ['gulp/build.js', /\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap/]
         ]));
 
         assert.noFileContent([].concat([

--- a/test/test-options.mocha.js
+++ b/test/test-options.mocha.js
@@ -128,7 +128,7 @@ describe('gulp-angular generator', function () {
           ['src/app/index.js', /'ngRoute'/],
 
           // Check src/app/vendor.scss
-          ['src/app/vendor.scss', /\$icon-font-path: "\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
+          ['src/app/vendor.scss', /\$icon-font-path: "\/bower_components\/bootstrap-sass-official\/assets\/fonts\/bootstrap\/";/],
           ['src/app/vendor.scss', /@import '\.\.\/\.\.\/bower_components\/bootstrap-sass-official\/assets\/stylesheets\/bootstrap';/],
 
           // Check bower.json


### PR DESCRIPTION
Started from #241 (thx @chhsiao1981)

Fixed the paths of the fonts of bootstrap for less and sass, for dev and dist. Checked for the 4 combinations.

Works for bootstrap 3.3.x, didn't find any problem for the 3.3.2 and the 3.3.3 doesn't exist for bootstrap in less.

fix #266