### PR TITLE
Add npm test support using scripts in package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,6 +2,9 @@
   "name": "<%= appName %>",
   "version": "0.0.0",
   "dependencies": {},
+  "scripts": {
+    "test": "gulp test"
+  },
   "devDependencies": {
     "gulp": "~3.8.10",
     "gulp-autoprefixer": "~2.0.0",


### PR DESCRIPTION
I think it's a good practice to make "npm test" execute all tests.