### PR TITLE
Fix static checking support (jshint, coffeelint, tslint)

### DIFF
--- a/app/src/preprocessors.js
+++ b/app/src/preprocessors.js
@@ -41,12 +41,10 @@ module.exports = function(GulpAngularGenerator) {
       this.injectTaskDeps.push('\'styles\'');
     }
 
-    if (this.props.jsPreprocessor.key !== 'none') {
-      if (this.props.jsPreprocessor.key === 'traceur') {
-        this.injectTaskDeps.push('\'browserify\'');
-      } else {
-        this.injectTaskDeps.push('\'scripts\'');
-      }
+    if (this.props.jsPreprocessor.key === 'traceur') {
+      this.injectTaskDeps.push('\'browserify\'');
+    } else {
+      this.injectTaskDeps.push('\'scripts\'');
     }
   };
 
@@ -58,10 +56,6 @@ module.exports = function(GulpAngularGenerator) {
   GulpAngularGenerator.prototype.rejectFiles = function rejectFiles() {
       if(this.props.cssPreprocessor.key === 'none') {
         rejectWithRegexp.call(this, /styles\.js/);
-      }
-
-      if(this.props.jsPreprocessor.key === 'none') {
-        rejectWithRegexp.call(this, /scripts\.js/);
       }
 
       if(this.props.jsPreprocessor.key !== 'typescript') {

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -10,10 +10,16 @@ var options = {
   dist: '<%= props.paths.dist %>',
   tmp: '<%= props.paths.tmp %>',
   e2e: '<%= props.paths.e2e %>',
-  errorHandler: function(title) {
+  failOnLintErrors: true,
+  failOnCompileErrors: true,
+  errorHandler: function(title, error) {
     return function(err) {
       gutil.log(gutil.colors.red('[' + title + ']'), err.toString());
-      this.emit('end');
+      if (error) {
+        throw err;
+      } else {
+        this.emit('end');
+      }
     };
   }
 };
@@ -25,5 +31,5 @@ wrench.readdirSyncRecursive('./gulp').filter(function(file) {
 });
 
 gulp.task('default', ['clean'], function () {
-    gulp.start('build');
+  gulp.start('build');
 });

--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -9,6 +9,7 @@ var source = require('vinyl-source-stream');
 var buffer = require('vinyl-buffer');
 <% } if (props.jsPreprocessor.key === 'babel') { %>
 var babelify = require('babelify');
+var merge = require('merge-stream');
 <% } %>
 
 var $ = require('gulp-load-plugins')();
@@ -21,23 +22,34 @@ module.exports = function(options) {
 <% } else { %>
   gulp.task('scripts', function () {
 <% } %>
-<% if (props.jsPreprocessor.key !== 'babel') { %>
-    return gulp.src(options.src + '/{app,components}/**/*.<%= props.jsPreprocessor.extension %>')
-<%   if (props.jsPreprocessor.extension === 'js') { %>
+    var scripts = gulp.src(options.src + '/{app,components}/**/*.<%= props.jsPreprocessor.extension %>')
+<% if (props.jsPreprocessor.extension === 'js') { %>
       .pipe($.jshint())
-      .pipe($.jshint.reporter('jshint-stylish'))
-<%   } if (props.jsPreprocessor.key !== 'none') { %>
+      .pipe($.jshint.reporter('jshint-stylish'));
+    if (options.failOnLintErrors) {
+      scripts = scripts.pipe($.jshint.reporter('fail'));
+    }
+<% } else if (props.jsPreprocessor.extension === 'coffee') { %>
+      .pipe($.coffeelint())
+      .pipe($.coffeelint.reporter());
+    if (options.failOnLintErrors) {
+      scripts = scripts.pipe($.coffeelint.reporter('fail'));
+    }
+<% } else if (props.jsPreprocessor.extension === 'ts') { %>
+      .pipe($.tslint())
+      .pipe($.tslint.report('prose', {emitError: options.failOnLintErrors}));
+<% } %>
+
+<% if (props.jsPreprocessor.key !== 'babel') { %>
+    scripts = scripts
+<%   if (props.jsPreprocessor.key !== 'none') { %>
       .pipe($.sourcemaps.init())
 <%   } if (props.jsPreprocessor.key === 'traceur') { %>
-      .pipe($.traceur()).on('error', options.errorHandler('Traceur'))
+      .pipe($.traceur()).on('error', options.errorHandler('Traceur', options.failOnCompileErrors))
 <%   } if (props.jsPreprocessor.key === 'coffee') { %>
-      .pipe($.coffeelint())
-      .pipe($.coffeelint.reporter())
-      .pipe($.coffee()).on('error', options.errorHandler('CoffeeScript'))
+      .pipe($.coffee()).on('error', options.errorHandler('CoffeeScript', options.failOnCompileErrors))
 <%   } if (props.jsPreprocessor.key === 'typescript') { %>
-      .pipe($.tslint())
-      .pipe($.tslint.report('prose', { emitError: false }))
-      .pipe($.typescript({sortOutput: true})).on('error', options.errorHandler('TypeScript'))
+      .pipe($.typescript({sortOutput: true})).on('error', options.errorHandler('TypeScript', options.failOnCompileErrors))
 <%   } %>
 <%   if (props.jsPreprocessor.key !== 'none') { %>
       .pipe($.sourcemaps.write())
@@ -51,16 +63,20 @@ module.exports = function(options) {
       .pipe(gulp.dest(options.tmp + '/serve/'))
 <%   } %>
       .pipe($.size());
+
+    return scripts;
 <% } else { %>
-    return browserify({ debug: true })
+    var browserifyStream = browserify({ debug: true })
       .add('./' + options.src + '/app/index.js')
       .transform(babelify)
-      .bundle().on('error', options.errorHandler('Browserify'))
+      .bundle().on('error', options.errorHandler('Browserify', options.failOnCompileErrors))
       .pipe(source('index.js'))
       .pipe(buffer())
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.sourcemaps.write())
       .pipe(gulp.dest(options.tmp + '/serve/app'));
+
+    return merge(browserifyStream, scripts)
 <% } %>
   });
 
@@ -68,7 +84,7 @@ module.exports = function(options) {
   gulp.task('browserify', ['scripts'], function () {
     return browserify({ debug: true })
       .add('./' + options.tmp + '/<%= props.jsPreprocessor.key %>/app/index.js')
-      .bundle().on('error', options.errorHandler('Browserify'))
+      .bundle().on('error', options.errorHandler('Browserify', options.failOnCompileErrors))
       .pipe(source('index.js'))
       .pipe(buffer())
       .pipe($.sourcemaps.init({ loadMaps: true }))

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -8,6 +8,8 @@ module.exports = function(options) {
 <% } else { %>
   gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
+    options.failOnLintErrors = false;
+    options.failOnCompileErrors = false;
     gulp.watch([
       options.src + '/*.html',
       options.src + '/{app,components}/**/*.<%= props.cssPreprocessor.extension %>',

--- a/app/templates/src/app/_index.ts
+++ b/app/templates/src/app/_index.ts
@@ -9,5 +9,7 @@ module <%= appName %> {
   angular.module('<%= appName %>', [<%= modulesDependencies %>])
     .controller('MainCtrl', MainCtrl)
     .controller('NavbarCtrl', NavbarCtrl)
-    <%= routerJs %>;
+<% if (routerJs) { %>
+    <%= routerJs.trim() %>
+<% } %>;
 }

--- a/test/node/test-preprocessors.js
+++ b/test/node/test-preprocessors.js
@@ -22,7 +22,6 @@ describe('gulp-angular generator preprocessors script', function () {
 
     generator.files = [
       { src: 'gulp/styles.js' },
-      { src: 'gulp/scripts.js' },
       { src: 'gulp/markups.js' },
       { src: 'gulp/tsd.js' },
       { src: 'tsd.json' }
@@ -47,13 +46,14 @@ describe('gulp-angular generator preprocessors script', function () {
   });
 
   describe('compute dependencies for the gulp inject task', function() {
-    it('should be empty if no preprocessors', function() {
+    it('should be scripts if no preprocessors', function() {
       generator.props = {
         cssPreprocessor: { key: 'none' },
         jsPreprocessor: { key: 'none' }
       };
       generator.computeInjectTaskDeps();
-      generator.injectTaskDeps.length.should.be.equal(0);
+      generator.injectTaskDeps.length.should.be.equal(1);
+      generator.injectTaskDeps[0].should.be.equal('\'scripts\'');
     });
 
     it('should be styles and scripts when there is preprocessors', function() {
@@ -67,7 +67,7 @@ describe('gulp-angular generator preprocessors script', function () {
       generator.injectTaskDeps[1].should.be.equal('\'scripts\'');
     });
 
-    it('should be browseridy for traceur', function() {
+    it('should be browserify for traceur', function() {
       generator.props = {
         cssPreprocessor: { key: 'none' },
         jsPreprocessor: { key: 'traceur' }
@@ -96,7 +96,7 @@ describe('gulp-angular generator preprocessors script', function () {
         htmlPreprocessor: { key: 'not none' }
       };
       generator.rejectFiles();
-      generator.files.length.should.be.equal(5);
+      generator.files.length.should.be.equal(4);
     });
   });
 
@@ -106,7 +106,7 @@ describe('gulp-angular generator preprocessors script', function () {
         jsPreprocessor: { key: 'coffee' }
       };
       generator.lintCopies();
-      generator.files[5].src.should.match(/coffeelint/);
+      generator.files[4].src.should.match(/coffeelint/);
     });
 
     it('should add tslint for typescript preprocessor', function() {
@@ -114,7 +114,7 @@ describe('gulp-angular generator preprocessors script', function () {
         jsPreprocessor: { key: 'typescript' }
       };
       generator.lintCopies();
-      generator.files[5].src.should.match(/tslint/);
+      generator.files[4].src.should.match(/tslint/);
     });
   });
 

--- a/test/template/test-scripts.js
+++ b/test/template/test-scripts.js
@@ -92,10 +92,10 @@ describe('gulp-angular scripts template', function () {
     model.props.jsPreprocessor.key = 'babel';
     model.props.jsPreprocessor.extension = 'js';
     result = scripts(model);
+    result.should.match(/gulp\.src\(options\.src \+ '[^\s]*\.js'\)/);
     result.should.match(/browserify\(\{ debug: true \}\)/);
     result.should.match(/\.add\('\.\/' \+ options\.src \+ '\/app\/index\.js'\)/);
     result.should.match(/\.transform\(babelify\)/);
-    result.should.not.match(/gulp\.src/);
     result.should.not.match(/traceur/);
     result.should.not.match(/coffee/);
     result.should.not.match(/typescript/);


### PR DESCRIPTION
This close #277, but also moves all jshint/coffeelint/tslint to a static.js gulp file, support two tasks : `static` and `static:fail`. 

`static` only displays warning, but `static:fail` also raise an error.

Those tasks are registered in `gulp build` (`static:fail`) and `gulp watch` (`static`).