### PR TITLE
Update 6to5 compile task, support sourcemaps

### DIFF
--- a/app/src/format.js
+++ b/app/src/format.js
@@ -119,7 +119,7 @@ module.exports = function () {
     this.injectTaskDeps.push('\'styles\'');
   }
   if (this.props.jsPreprocessor.key !== 'none') {
-    if (this.props.jsPreprocessor.extension === 'js') {
+    if (this.props.jsPreprocessor.key === 'traceur') {
       this.injectTaskDeps.push('\'browserify\'');
     } else {
       this.injectTaskDeps.push('\'scripts\'');

--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -1,12 +1,20 @@
 'use strict';
 
 var gulp = require('gulp');
+var gutil = require('gulp-util');
 
 gulp.paths = {
   src: '<%= props.paths.src %>',
   dist: '<%= props.paths.dist %>',
   tmp: '<%= props.paths.tmp %>',
   e2e: '<%= props.paths.e2e %>'
+};
+
+gulp.errorHandler = function(title) {
+  return function(err) {
+    gutil.log(gutil.colors.red('[' + title + ']'), err.toString());
+    this.emit('end');
+  };
 };
 
 require('require-dir')('./gulp');

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -35,7 +35,11 @@
     "<%= props.jsPreprocessor.module %>": "<%= props.jsPreprocessor.version %>",
     "gulp-sourcemaps": "~1.3.0",
 <% } if (props.jsPreprocessor.srcExtension === 'es6') { %>
-    "gulp-browserify": "~0.5.0",
+    "browserify": "~8.1.1",
+    "vinyl-buffer": "~1.0.0",
+    "vinyl-source-stream": "~1.0.0",
+<% } if (props.jsPreprocessor.key === '6to5') { %>
+    "6to5ify": "~3.1.2",
 <% } if (props.jsPreprocessor.key === 'typescript') { %>
     "gulp-tslint": "~1.4.1",
     "gulp-to-json": "~1.0.1",

--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -1,66 +1,85 @@
 'use strict';
 
 var gulp = require('gulp');
+
 <% if (props.jsPreprocessor.key === 'typescript') { %>
 var mkdirp = require('mkdirp');
+<% } if (props.jsPreprocessor.srcExtension === 'es6') { %>
+var browserify = require('browserify');
+var source = require('vinyl-source-stream');
+var buffer = require('vinyl-buffer');
+<% } if (props.jsPreprocessor.key === '6to5') { %>
+var to5ify = require('6to5ify');
 <% } %>
+
 var paths = gulp.paths;
 
 var $ = require('gulp-load-plugins')();
 
-gulp.task('scripts',
-<% if (props.jsPreprocessor.key === 'typescript') { %> ['tsd:install'],
-<% } %> function () {
 <% if (props.jsPreprocessor.key === 'typescript') { %>
+gulp.task('scripts', ['tsd:install'], function () {
   mkdirp.sync(paths.tmp);
-<% } %>
 
+<% } else { %>
+gulp.task('scripts', function () {
+<% } %>
+<% if (props.jsPreprocessor.key !== '6to5') { %>
   return gulp.src(paths.src + '/{app,components}/**/*.<%= props.jsPreprocessor.extension %>')
-<% if (props.jsPreprocessor.extension === 'js') { %>
+<%   if (props.jsPreprocessor.extension === 'js') { %>
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
-<% } if (props.jsPreprocessor.key !== 'none') { %>
+<%   } if (props.jsPreprocessor.key !== 'none') { %>
     .pipe($.sourcemaps.init())
-<% } if (props.jsPreprocessor.key === '6to5') { %>
-    .pipe($['6to5']())
-<% } if (props.jsPreprocessor.key === 'traceur') { %>
+<%   } if (props.jsPreprocessor.key === 'traceur') { %>
     .pipe($.traceur())
-<% } if (props.jsPreprocessor.key === 'coffee') { %>
+    .on('error', gulp.errorHandler('Traceur'))
+<%   } if (props.jsPreprocessor.key === 'coffee') { %>
     .pipe($.coffeelint())
     .pipe($.coffeelint.reporter())
     .pipe($.coffee())
-<% } if (props.jsPreprocessor.key === 'typescript') { %>
+    .on('error', gulp.errorHandler('CoffeeScript'))
+<%   } if (props.jsPreprocessor.key === 'typescript') { %>
     .pipe($.tslint())
-    .pipe($.tslint.report('prose', {emitError: false}))
+    .pipe($.tslint.report('prose', { emitError: false }))
     .pipe($.typescript({sortOutput: true}))
-<% } %>
-    .on('error', function handleError(err) {
-      console.error(err.toString());
-      this.emit('end');
-    })
-<% if (props.jsPreprocessor.key !== 'none') { %>
+    .on('error', gulp.errorHandler('TypeScript'))
+<%   } %>
+<%   if (props.jsPreprocessor.key !== 'none') { %>
     .pipe($.sourcemaps.write())
-<% } %>
-<% if (props.jsPreprocessor.key === 'typescript') { %>
+<%   } %>
+<%   if (props.jsPreprocessor.key === 'typescript') { %>
     .pipe($.toJson({filename: paths.tmp + '/sortOutput.json', relative:true}))
-<% } %>
-<% if (props.jsPreprocessor.srcExtension === 'es6') { %>
-    .pipe(gulp.dest(paths.tmp + '/<%= props.jsPreprocessor.key %>'))
-<% } else if (props.jsPreprocessor.key !== 'none') { %>
+<%   } %>
+<%   if (props.jsPreprocessor.key === 'traceur') { %>
+    .pipe(gulp.dest(paths.tmp + '/traceur'))
+<%   } else if (props.jsPreprocessor.key !== 'none') { %>
     .pipe(gulp.dest(paths.tmp + '/serve/'))
-<% } %>
+<%   } %>
     .pipe($.size());
+<% } else { %>
+  return browserify({ debug: true })
+    .add('./' + paths.src + '/app/index.js')
+    .transform(to5ify)
+    .bundle()
+    .on('error', gulp.errorHandler('Browserify'))
+    .pipe(source('index.js'))
+    .pipe(buffer())
+    .pipe($.sourcemaps.init({ loadMaps: true }))
+    .pipe($.sourcemaps.write())
+    .pipe(gulp.dest(paths.tmp + '/serve/app'));
+<% } %>
 });
 
-<% if (props.jsPreprocessor.srcExtension === 'es6') { %>
+<% if (props.jsPreprocessor.key === 'traceur') { %>
 gulp.task('browserify', ['scripts'], function () {
-  return gulp.src(paths.tmp + '/<%= props.jsPreprocessor.key %>/app/index.js', { read: false })
-    .pipe($.browserify())
-    .on('error', function handleError(err) {
-      console.error(err.toString());
-      this.emit('end');
-    })
-    .pipe(gulp.dest(paths.tmp + '/serve/app'))
-    .pipe($.size());
+  return browserify({ debug: true })
+    .add('./' + paths.tmp + '/<%= props.jsPreprocessor.key %>/app/index.js')
+    .bundle()
+    .on('error', gulp.errorHandler('Browserify'))
+    .pipe(source('index.js'))
+    .pipe(buffer())
+    .pipe($.sourcemaps.init({ loadMaps: true }))
+    .pipe($.sourcemaps.write())
+    .pipe(gulp.dest(paths.tmp + '/serve/app'));
 });
 <% } %>

--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -49,7 +49,7 @@ function runTests (singleRun, done) {
 <% if (props.jsPreprocessor.key === 'none') { %>
 gulp.task('test', function (done) { runTests(true /* singleRun */, done) });
 gulp.task('test:auto', function (done) { runTests(false /* singleRun */, done) });
-<% } else if (props.jsPreprocessor.extension === 'js') { %>
+<% } else if (props.jsPreprocessor.key === 'traceur') { %>
 gulp.task('test', ['browserify'], function (done) { runTests(true /* singleRun */, done) });
 gulp.task('test:auto', ['browserify'], function (done) { runTests(false /* singleRun */, done) });
 <% } else { %>

--- a/test/deps/package.json
+++ b/test/deps/package.json
@@ -47,19 +47,21 @@
     "gulp-coffee": "~2.2.0",
     "gulp-coffeelint": "~0.4.0",
     "gulp-traceur": "~0.14.1",
-    "gulp-6to5": "~1.0.2",
     "gulp-typescript": "~2.4.0",
     "gulp-tslint": "~1.4.1",
     "gulp-to-json": "~1.0.1",
     "gulp-order": "~1.1.1",
+    "gulp-sourcemaps": "~1.3.0",
     "mkdirp": "~0.5.0",
     "tsd": "~0.6.0-beta.5",
-    "gulp-browserify": "~0.5.0",
-    "gulp-sourcemaps": "~1.3.0",
     "jade": "~1.8.1",
     "hamljs": "~0.6.2",
     "handlebars": "~2.0.0",
-    "qrcode-terminal": "~0.9.5"
+    "qrcode-terminal": "~0.9.5",
+    "browserify": "~8.1.1",
+    "vinyl-buffer": "~1.0.0",
+    "vinyl-source-stream": "~1.0.0",
+    "6to5ify": "~3.1.2"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/test-files-generate.mocha.js
+++ b/test/test-files-generate.mocha.js
@@ -956,11 +956,13 @@ describe('gulp-angular generator', function () {
         ]);
 
         assert.fileContent([].concat(expectedGulpContent, [
-          ['gulp/scripts.js', /gulp\.task\(\'browserify\'/],
-          ['gulp/inject.js', /gulp\.task\('inject', \['styles', 'browserify'\]/],
+          ['gulp/scripts.js', /gulp\.task\(\'scripts\'/],
+          ['gulp/inject.js', /gulp\.task\('inject', \['styles', 'scripts'\]/],
           ['gulp/inject.js', /paths\.tmp \+ '\/serve\/{app,components}\/\*\*\/\*\.js',/],
-          ['package.json', /gulp-6to5/],
-          ['package.json', /gulp-browserify/]
+          ['package.json', /browserify/],
+          ['package.json', /6to5ify/],
+          ['package.json', /vinyl-buffer/],
+          ['package.json', /vinyl-source-stream/]
         ]));
 
         done();
@@ -994,8 +996,9 @@ describe('gulp-angular generator', function () {
           ['gulp/scripts.js', /gulp\.task\(\'browserify\'/],
           ['gulp/inject.js', /gulp\.task\('inject', \['styles', 'browserify'\]/],
           ['gulp/inject.js', /paths\.tmp \+ '\/serve\/{app,components}\/\*\*\/\*\.js',/],
-          ['package.json', /gulp-traceur/],
-          ['package.json', /gulp-browserify/],
+          ['package.json', /browserify/],
+          ['package.json', /vinyl-buffer/],
+          ['package.json', /vinyl-source-stream/],
           ['bower.json', /traceur-runtime/]
         ]));
 


### PR DESCRIPTION
This update use the new guidelines for browserify with gulp.

https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-uglify-sourcemap.md

It simplify and gives us sourcemap support.

Unfortunately the Traceur plugin for Browserify is deprecated so I can't do the same. The other lead is to use traceur to make his own bundleling but it's not ready yet: https://github.com/sindresorhus/gulp-traceur/issues/17