### PR TITLE
Jade configuration improvements

### DIFF
--- a/app/templates/gulp/_markups.js
+++ b/app/templates/gulp/_markups.js
@@ -13,7 +13,7 @@ gulp.task('markups', function() {
 
   return gulp.src(paths.src + '/{app,components}/**/*.<%= props.htmlPreprocessor.extension %>')
 <% if (props.htmlPreprocessor.key === 'jade') { %>
-    .pipe($.consolidate('jade', { pretty: '  ' }))
+    .pipe($.consolidate('jade', { basedir: paths.src, doctype: 'html', pretty: '  ' }))
 <% } else if (props.htmlPreprocessor.key === 'haml') { %>
     .pipe($.consolidate('hamljs'))
 <% } else if (props.htmlPreprocessor.key === 'handlebars') { %>


### PR DESCRIPTION
I noticed that jade by default is compiling no-value attributes in the html4 compliant way, like translate="translate" This breaks a lots of angular directives, which normally expects just translate attribute. So "doctype: 'html'" fixes it. "basedir: paths.src" helps with locating reused jade templates.