### PR TITLE
Fix missing fonts directory from serve task

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -82,16 +82,30 @@ gulp.task('images', function () {
     .pipe(gulp.dest(paths.dist + '/assets/images/'));
 });
 
-gulp.task('fonts', function () {
-  var customFonts = gulp.src(paths.src + '/assets/fonts/**/*')
+gulp.task('fonts:tmp', function() {
+  return gulp.src($.mainBowerFiles(), {base: 'bower_components'})
+    .pipe($.filter('**/*.{eot,svg,ttf,woff,woff2}'))
+    .pipe($.rename(function(path) {
+      var fontsIndex = path.dirname.indexOf('fonts');
+      if (fontsIndex > 0) {
+        // Keep folder structure from fonts directory
+        path.dirname = path.dirname.substring(fontsIndex + 5);
+        path.dirname  = (path.dirname.length && path.dirname [0] === '/') ? path.dirname .slice(1) : path.dirname;
+      } else {
+        path.dirname = '';
+      }
+    }))
+    .pipe(gulp.dest(paths.tmp + '/serve/fonts/'));
+});
+
+gulp.task('fonts', ['fonts:tmp'], function () {
+  var srcFonts = gulp.src(paths.src + '/assets/fonts/**/*')
     .pipe(gulp.dest(paths.dist + '/assets/fonts/'));
 
-  var bowerFonts = gulp.src($.mainBowerFiles())
-    .pipe($.filter('**/*.{eot,svg,ttf,woff,woff2}'))
-    .pipe($.flatten())
+  var tmpFonts = gulp.src(paths.tmp + '/serve/fonts/**/*')
     .pipe(gulp.dest(paths.dist + '/fonts/'));
 
-  return merge(customFonts, bowerFonts);
+  return merge(srcFonts, tmpFonts);
 });
 
 gulp.task('misc', function () {

--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -41,7 +41,7 @@ function browserSyncInit(baseDir, files, browser) {
 <% } %>
 }
 
-gulp.task('serve', ['watch'], function () {
+gulp.task('serve', ['watch', 'fonts:tmp'], function () {
   browserSyncInit([
     paths.tmp + '/serve',
     paths.src
@@ -55,7 +55,9 @@ gulp.task('serve', ['watch'], function () {
 <% } else { %>
     paths.tmp + '/serve/{app,components}/**/*.js',
 <% } %>
-    paths.src + 'src/assets/images/**/*',
+    paths.src + '/assets/images/**/*',
+    paths.src + '/assets/fonts/**/*',
+    paths.tmp + '/serve/fonts/**/*',
     paths.tmp + '/serve/*.html',
     paths.tmp + '/serve/{app,components}/**/*.html',
     paths.src + '/{app,components}/**/*.html'

--- a/app/templates/src/assets/fonts/README
+++ b/app/templates/src/assets/fonts/README
@@ -1,1 +1,0 @@
-Place your custom fonts in this directory.


### PR DESCRIPTION
Fonts were not loaded properly in `gulp serve`.

It also support more CSS fonts from bower dependencies, by keeping the folder structure after `fonts` instead of always flattening it. For example, if `bower.json` `main` property defines `dist/fonts/md-icon/md-icon.svg`, it will copy the font to `.tmp/serve/fonts/md-icon/md-icon.svg`.

This also replace README with an empty .gitignore to avoid README file to be served.