### PR TITLE
Fixed error in prefix while processing css map files

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -29,6 +29,7 @@
     "gulp-rev": "~2.0.1",
     "gulp-rev-replace": "~0.3.1",
     "gulp-minify-html": "~0.1.7",
+    "gulp-ignore": "~1.2.1",
     "gulp-inject": "~1.0.2",
     "gulp-protractor": "~0.0.11",
     "gulp-karma": "~0.0.4",

--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -58,7 +58,7 @@ gulp.task('styles', function () {
 <% } else if (props.cssPreprocessor.key === 'stylus') { %>
     .pipe($.stylus())
 <% } %>
-
+  .pipe($.ignore.exclude('*.map'))
   .pipe($.autoprefixer())
     .on('error', function handleError(err) {
       console.error(err.toString());


### PR DESCRIPTION
When using a css preprocessor that generate source map files, the prefixer plugin will crash due to map file.
Screenshot: http://screencast.com/t/SfFT3Tb9Xye6