### PR TITLE
Added new name of the 6to5 project: Babel

### DIFF
--- a/app/prompts.json
+++ b/app/prompts.json
@@ -363,7 +363,7 @@
           "module": "gulp-6to5",
           "version": "~1.0.2"
         },
-        "name": "ES6 (6to5), ECMAScript 6 compiled with 6to5 which requires no runtime."
+        "name": "ES6 (Babel formerly 6to5), ECMAScript 6 compiled with Babel which requires no runtime."
       },
       {
         "value": {


### PR DESCRIPTION
The 6to5 project changed name recently (https://babeljs.io/blog/2015/02/15/not-born-to-die/), this modification adds its new name (Babel) to the prompt.
I haven't touched to the module required, it is still named 6to5, but we could replace it by the new version (https://github.com/babel/gulp-babel).