### PR TITLE
Better watch task and control browser sync reload from gulp

### DIFF
--- a/app/templates/gulp/_markups.js
+++ b/app/templates/gulp/_markups.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
 
 var $ = require('gulp-load-plugins')();
 
@@ -23,6 +24,7 @@ module.exports = function(options) {
         this.emit('end');
       })
       .pipe($.rename(renameToHtml))
-      .pipe(gulp.dest(options.tmp + '/serve/'));
+      .pipe(gulp.dest(options.tmp + '/serve/'))
+      .pipe(browserSync.reload({ stream: true }));
   });
 };

--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
 <% if (props.jsPreprocessor.key === 'typescript') { %>
 var mkdirp = require('mkdirp');
 <% } if (props.jsPreprocessor.srcExtension === 'es6') { %>
@@ -50,6 +51,7 @@ module.exports = function(options) {
 <%   } else if (props.jsPreprocessor.key !== 'none') { %>
       .pipe(gulp.dest(options.tmp + '/serve/'))
 <%   } %>
+      .pipe(browserSync.reload({ stream: true }))
       .pipe($.size());
 <% } else { %>
     return browserify({ debug: true })
@@ -60,7 +62,9 @@ module.exports = function(options) {
       .pipe(buffer())
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.sourcemaps.write())
-      .pipe(gulp.dest(options.tmp + '/serve/app'));
+      .pipe(gulp.dest(options.tmp + '/serve/app'))
+      .pipe(browserSync.reload({ stream: true }))
+      .pipe($.size());
 <% } %>
   });
 
@@ -73,7 +77,9 @@ module.exports = function(options) {
       .pipe(buffer())
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.sourcemaps.write())
-      .pipe(gulp.dest(options.tmp + '/serve/app'));
+      .pipe(gulp.dest(options.tmp + '/serve/app'))
+      .pipe(browserSync.reload({ stream: true }))
+      .pipe($.size());
   });
 <% } %>
 };

--- a/app/templates/gulp/_server.js
+++ b/app/templates/gulp/_server.js
@@ -1,12 +1,10 @@
 'use strict';
 
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
+var browserSyncSpa = require('browser-sync-spa');
 
 var util = require('util');
-
-var browserSync = require('browser-sync');
-
-var spa = require('browser-sync-spa');
 
 var middleware = require('./proxy');
 
@@ -16,10 +14,8 @@ module.exports = function(options) {
   var qrcode = require('qrcode-terminal');
 <% } %>
 
-  function browserSyncInit(baseDir, files, browser) {
+  function browserSyncInit(baseDir, browser) {
     browser = browser === undefined ? 'default' : browser;
-
-    files = files ? files : [];
 
     var routes = null;
     if(baseDir === options.src || (util.isArray(baseDir) && baseDir.indexOf(options.src) !== -1)) {
@@ -37,7 +33,7 @@ module.exports = function(options) {
       server.middleware = middleware;
     }
 
-    browserSync.instance = browserSync.init(files, {
+    browserSync.instance = browserSync.init({
       startPath: '/',
       server: server,
       browser: browser
@@ -50,41 +46,23 @@ module.exports = function(options) {
 <% } %>
   }
 
-  browserSync.use(spa({
+  browserSync.use(browserSyncSpa({
     selector: '[ng-app]'// Only needed for angular apps
   }));
 
-
-gulp.task('serve', ['watch'], function () {
-  browserSyncInit([
-    options.tmp + '/serve',
-    options.src
-  ], [
-<% if(props.cssPreprocessor.key === 'none') { %>
-    options.src + '/{app,components}/**/*.css',
-<% } else { %>
-    options.tmp + '/serve/{app,components}/**/*.css',
-<% } if(props.jsPreprocessor.key === 'none') { %>
-    options.src + '/{app,components}/**/*.js',
-<% } else { %>
-    options.tmp + '/serve/{app,components}/**/*.js',
-<% } %>
-    options.src + '/assets/images/**/*',
-    options.tmp + '/serve/*.html',
-    options.tmp + '/serve/{app,components}/**/*.html',
-    options.src + '/{app,components}/**/*.html'
-  ]);
-});
+  gulp.task('serve', ['watch'], function () {
+    browserSyncInit([options.tmp + '/serve', options.src]);
+  });
 
   gulp.task('serve:dist', ['build'], function () {
     browserSyncInit(options.dist);
   });
 
   gulp.task('serve:e2e', ['inject'], function () {
-    browserSyncInit([options.tmp + '/serve', options.src], null, []);
+    browserSyncInit([options.tmp + '/serve', options.src], []);
   });
 
   gulp.task('serve:e2e-dist', ['build'], function () {
-    browserSyncInit(options.dist, null, []);
+    browserSyncInit(options.dist, []);
   });
 };

--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
 
 var $ = require('gulp-load-plugins')();
 
@@ -56,6 +57,7 @@ module.exports = function(options) {
     .pipe($.stylus()).on('error', options.errorHandler('Stylus'))
 <% } %>
     .pipe($.autoprefixer()).on('error', options.errorHandler('Autoprefixer'))
-    .pipe(gulp.dest(options.tmp + '/serve/app/'));
+    .pipe(gulp.dest(options.tmp + '/serve/app/'))
+    .pipe(browserSync.reload({ stream: true }));
   });
 };

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -1,6 +1,11 @@
 'use strict';
 
 var gulp = require('gulp');
+var browserSync = require('browser-sync');
+
+function isOnlyChange(event) {
+  return event.type === 'changed';
+}
 
 module.exports = function(options) {
 <% if (props.htmlPreprocessor.key === 'none') { %>
@@ -8,15 +13,49 @@ module.exports = function(options) {
 <% } else { %>
   gulp.task('watch', ['markups', 'inject'], function () {
 <% } %>
+
+    gulp.watch([options.src + '/*.html', 'bower.json'], ['inject']);
+
+<% if (props.cssPreprocessor.extension === 'css') { %>
+    gulp.watch(options.src + '/{app,components}/**/*.css', function(event) {
+<% } else { %>
     gulp.watch([
-      options.src + '/*.html',
-      options.src + '/{app,components}/**/*.<%= props.cssPreprocessor.extension %>',
-      options.src + '/{app,components}/**/*.js',
-<% if (props.jsPreprocessor.extension !== 'js') { %>
-      options.src + '/{app,components}/**/*.<%= props.jsPreprocessor.extension %>',
+      options.src + '/{app,components}/**/*.css',
+      options.src + '/{app,components}/**/*.<%= props.cssPreprocessor.extension %>'
+    ], function(event) {
 <% } %>
-      'bower.json'
-    ], ['inject']);
+      if(isOnlyChange(event)) {
+<% if (props.cssPreprocessor.key === 'none') { %>
+        browserSync.reload(event.path);
+<% } else { %>
+        gulp.start('styles');
+<% } %>
+      } else {
+        gulp.start('inject');
+      }
+    });
+
+<% if (props.jsPreprocessor.extension === 'js') { %>
+    gulp.watch(options.src + '/{app,components}/**/*.js', function(event) {
+<% } else { %>
+    gulp.watch([
+      options.src + '/{app,components}/**/*.js',
+      options.src + '/{app,components}/**/*.<%= props.jsPreprocessor.extension %>'
+    ], function(event) {
+<% } %>
+      if(isOnlyChange(event)) {
+<% if (props.jsPreprocessor.key === 'none') { %>
+        browserSync.reload(event.path);
+<% } else if (props.jsPreprocessor.key !== 'traceur') { %>
+        gulp.start('scripts');
+<% } else { %>
+        gulp.start('browserify');
+<% } %>
+      } else {
+        gulp.start('inject');
+      }
+    });
+
 <% if (props.htmlPreprocessor.key !== 'none') { %>
     gulp.watch(options.src + '/{app,components}/**/*.<%= props.htmlPreprocessor.extension %>', ['markups']);
 <% } %>

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "q": "^1.1.2",
     "recursive-readdir": "^1.2.1",
     "sinon": "^1.12.2",
-    "sinon-chai": "^2.6.0",
+    "sinon-chai": "^2.7.0",
     "wrench": "^1.5.8"
   },
   "peerDependencies": {

--- a/test/template/test-scripts.js
+++ b/test/template/test-scripts.js
@@ -27,7 +27,7 @@ describe('gulp-angular scripts template', function () {
     model.props.jsPreprocessor.key = 'none';
     model.props.jsPreprocessor.srcExtension = 'js';
     var result = scripts(model);
-    result.should.match(/require\('gulp'\);\n\nvar \$/);
+    result.should.match(/var browserSync = require\('browser-sync'\);\n\nvar \$/);
 
     model.props.jsPreprocessor.key = 'typescript';
     result = scripts(model);

--- a/test/template/test-server.js
+++ b/test/template/test-server.js
@@ -34,18 +34,4 @@ describe('gulp-angular server template', function () {
     result.should.match(/qrcode\.generate/);
   });
 
-  it('should watch files from src or tmp depending of preprocessors', function() {
-    model.props.cssPreprocessor.key = 'none';
-    model.props.jsPreprocessor.key = 'none';
-    var result = server(model);
-    result.should.match(/options\.src \+ '[^\s]*\.css'/);
-    result.should.match(/options\.src \+ '[^\s]*\.js'/);
-
-    model.props.cssPreprocessor.key = 'not none';
-    model.props.jsPreprocessor.key = 'not none';
-    result = server(model);
-    result.should.match(/options\.tmp \+ '\/serve[^\s]*\.css'/);
-    result.should.match(/options\.tmp \+ '\/serve[^\s]*\.js'/);
-  });
-
 });

--- a/test/template/test-watch.js
+++ b/test/template/test-watch.js
@@ -33,14 +33,37 @@ describe('gulp-angular watch template', function () {
     result.should.match(/markups/);
   });
 
+  it('should watch the css preprocessor extension files and launch the styles task', function() {
+    model.props.cssPreprocessor.key = 'none';
+    model.props.cssPreprocessor.extension = 'css';
+    var result = watch(model);
+    result.should.match(/gulp\.watch\(.*\*\.css',/);
+    result.should.match(/browserSync\.reload/);
+
+    model.props.cssPreprocessor.key = 'notnone';
+    model.props.cssPreprocessor.extension = 'notcss';
+    result = watch(model);
+    result.should.match(/gulp\.watch\(\[\n.*\.css',\n.*\.notcss'\n.*\],/);
+    result.should.match(/gulp\.start\('styles'\);/);
+  });
+
   it('should watch the js preprocessor extension files', function() {
+    model.props.jsPreprocessor.key = 'none';
     model.props.jsPreprocessor.extension = 'js';
     var result = watch(model);
-    result.should.match(/gulp\.watch\(\[\n.*\n.*\n.*\n.*\n\s*\]/);
+    result.should.match(/gulp\.watch\(.*\*\.js',/);
+    result.should.match(/browserSync\.reload/);
 
+    model.props.jsPreprocessor.key = 'notnone';
     model.props.jsPreprocessor.extension = 'notjs';
     result = watch(model);
-    result.should.match(/options\.src \+ '[^\s]*\.notjs'/);
+    result.should.match(/gulp\.watch\(\[\n.*\.js',\n.*\.notjs'\n.*\],/);
+    result.should.match(/gulp\.start\('scripts'\);/);
+
+    model.props.jsPreprocessor.key = 'traceur';
+    model.props.jsPreprocessor.extension = 'js';
+    result = watch(model);
+    result.should.match(/gulp\.start\('browserify'\);/);
   });
 
   it('should watch the html preprocessor extension files', function() {


### PR DESCRIPTION
The current watch task is a little bold: watching everything, relaunch inject task and reload everything. Also, we don't use the browser sync API allowing to trigger reload from the gulp scripts.

This changes aims to create a better watch task which test the kind of changes for choosing between inject or scripts / styles task. Also I removed all the file watching from browser sync and now it's our tasks which trigger browser sync reloads.

Fix #384 