### PR TITLE
Fix lintering

### DIFF
--- a/app/src/preprocessors.js
+++ b/app/src/preprocessors.js
@@ -41,12 +41,10 @@ module.exports = function(GulpAngularGenerator) {
       this.injectTaskDeps.push('\'styles\'');
     }
 
-    if (this.props.jsPreprocessor.key !== 'none') {
-      if (this.props.jsPreprocessor.key === 'traceur') {
-        this.injectTaskDeps.push('\'browserify\'');
-      } else {
-        this.injectTaskDeps.push('\'scripts\'');
-      }
+    if (this.props.jsPreprocessor.key === 'traceur') {
+      this.injectTaskDeps.push('\'browserify\'');
+    } else {
+      this.injectTaskDeps.push('\'scripts\'');
     }
   };
 
@@ -58,10 +56,6 @@ module.exports = function(GulpAngularGenerator) {
   GulpAngularGenerator.prototype.rejectFiles = function rejectFiles() {
       if(this.props.cssPreprocessor.key === 'none') {
         rejectWithRegexp.call(this, /styles\.js/);
-      }
-
-      if(this.props.jsPreprocessor.key === 'none') {
-        rejectWithRegexp.call(this, /scripts\.js/);
       }
 
       if(this.props.jsPreprocessor.key !== 'typescript') {

--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -41,10 +41,7 @@ module.exports = function(options) {
       }))
   }
 
-<% if (props.jsPreprocessor.key === 'none') { %>
-  gulp.task('test', runTests.bind(this, true));
-  gulp.task('test:auto', runTests.bind(this, false));
-<% } else if (props.jsPreprocessor.key === 'traceur') { %>
+<% if (props.jsPreprocessor.key === 'traceur') { %>
   gulp.task('test', ['browserify'], runTests.bind(this, true));
   gulp.task('test:auto', ['browserify'], runTests.bind(this, false));
 <% } else { %>

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -1,7 +1,9 @@
 'use strict';
 
 var gulp = require('gulp');
+<% if (props.cssPreprocessor.key === 'none') { %>
 var browserSync = require('browser-sync');
+<% } %>
 
 function isOnlyChange(event) {
   return event.type === 'changed';

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -44,9 +44,7 @@ module.exports = function(options) {
     ], function(event) {
 <% } %>
       if(isOnlyChange(event)) {
-<% if (props.jsPreprocessor.key === 'none') { %>
-        browserSync.reload(event.path);
-<% } else if (props.jsPreprocessor.key !== 'traceur') { %>
+<% if (props.jsPreprocessor.key !== 'traceur') { %>
         gulp.start('scripts');
 <% } else { %>
         gulp.start('browserify');

--- a/test/node/test-preprocessors.js
+++ b/test/node/test-preprocessors.js
@@ -47,13 +47,14 @@ describe('gulp-angular generator preprocessors script', function () {
   });
 
   describe('compute dependencies for the gulp inject task', function() {
-    it('should be empty if no preprocessors', function() {
+    it('should be scripts if no preprocessors', function() {
       generator.props = {
         cssPreprocessor: { key: 'none' },
         jsPreprocessor: { key: 'none' }
       };
       generator.computeInjectTaskDeps();
-      generator.injectTaskDeps.length.should.be.equal(0);
+      generator.injectTaskDeps.length.should.be.equal(1);
+      generator.injectTaskDeps[0].should.be.equal('\'scripts\'');
     });
 
     it('should be styles and scripts when there is preprocessors', function() {
@@ -67,7 +68,7 @@ describe('gulp-angular generator preprocessors script', function () {
       generator.injectTaskDeps[1].should.be.equal('\'scripts\'');
     });
 
-    it('should be browseridy for traceur', function() {
+    it('should be browserify for traceur', function() {
       generator.props = {
         cssPreprocessor: { key: 'none' },
         jsPreprocessor: { key: 'traceur' }
@@ -86,7 +87,7 @@ describe('gulp-angular generator preprocessors script', function () {
         htmlPreprocessor: { key: 'none' }
       };
       generator.rejectFiles();
-      generator.files.length.should.be.equal(0);
+      generator.files.length.should.be.equal(1);
     });
 
     it('should reject nothing if there is preprocessors including TypeScript', function() {

--- a/test/template/test-unit-tests.js
+++ b/test/template/test-unit-tests.js
@@ -54,18 +54,13 @@ describe('gulp-angular unit tests template', function () {
   it('should select the right deps for the test tasks', function() {
     model.props.jsPreprocessor.key = 'none';
     var result = unitTests(model);
-    result.should.match(/task\('test', runTests\./);
-    result.should.match(/task\('test:auto', runTests\./);
+    result.should.match(/task\('test', \['scripts'\], runTests\./);
+    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
 
     model.props.jsPreprocessor.key = 'traceur';
     result = unitTests(model);
     result.should.match(/task\('test', \['browserify'\], runTests\./);
     result.should.match(/task\('test:auto', \['browserify'\], runTests\./);
-
-    model.props.jsPreprocessor.key = 'not traceur';
-    result = unitTests(model);
-    result.should.match(/task\('test', \['scripts'\], runTests\./);
-    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
   });
 
 });

--- a/test/template/test-watch.js
+++ b/test/template/test-watch.js
@@ -52,7 +52,7 @@ describe('gulp-angular watch template', function () {
     model.props.jsPreprocessor.extension = 'js';
     var result = watch(model);
     result.should.match(/gulp\.watch\(.*\*\.js',/);
-    result.should.match(/browserSync\.reload/);
+    result.should.match(/gulp\.start\('scripts'\);/);
 
     model.props.jsPreprocessor.key = 'notnone';
     model.props.jsPreprocessor.extension = 'notjs';


### PR DESCRIPTION
The workflow should run linter for task `gulp build` `gulp test` `gulp protractor` `gulp serve` and when watching files (add, edit, delete)

* [x] Javascript (:heavy_check_mark: build :heavy_check_mark: test :heavy_check_mark: protractor :heavy_check_mark: serve :heavy_check_mark: watch)
* [x] Coffeescript (:heavy_check_mark: build :heavy_check_mark: test :heavy_check_mark: protractor :heavy_check_mark: serve :heavy_check_mark: watch)
* [x] Traceur (:heavy_check_mark: build :heavy_check_mark: test :heavy_check_mark: protractor :heavy_check_mark: serve :heavy_check_mark: watch)
* [ ] Babel (:x: build :x: test :x: protractor :x: serve :x: watch)
* [x] Typescript (:heavy_check_mark: build :heavy_check_mark: test :heavy_check_mark: protractor :heavy_check_mark: serve :heavy_check_mark: watch)


***
close #326 close #277 close #279 