### PR TITLE
Use Chrome browser instead of PhantomJS for Traceur

### DIFF
--- a/app/files.json
+++ b/app/files.json
@@ -25,6 +25,8 @@
     "bower.json",
     "tsd.json",
 
+    "karma.conf.js",
+
     "e2e/main.po.js",
 
     "gulpfile.js",

--- a/app/templates/_karma.conf.js
+++ b/app/templates/_karma.conf.js
@@ -7,11 +7,20 @@ module.exports = function(config) {
 
     frameworks: ['jasmine'],
 
+<% if(props.jsPreprocessor.key === 'traceur') { %>
+    browsers : ['Chrome'],
+
+    plugins : [
+        'karma-chrome-launcher',
+        'karma-jasmine'
+    ]
+<% } else {%>
     browsers : ['PhantomJS'],
 
     plugins : [
         'karma-phantomjs-launcher',
         'karma-jasmine'
     ]
+<% } %>
   });
 };

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -74,7 +74,11 @@
     "jshint-stylish": "~1.0.0",
     "wiredep": "~2.2.0",
     "karma-jasmine": "~0.3.1",
+<% if(props.jsPreprocessor.key === 'traceur') { %>
+    "karma-chrome-launcher": "~0.1.7",
+<% } else {%>
     "karma-phantomjs-launcher": "~0.1.4",
+<% } %>
     "require-dir": "~0.1.0",
     "browser-sync": "~2.1.4",
     "browser-sync-spa": "~1.0.1",

--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -41,12 +41,6 @@ module.exports = function(options) {
       }));
   }
 
-<% if (props.jsPreprocessor.key === 'traceur') { %>
-  gulp.task('test', ['browserify'], runTests.bind(this, true));
-  gulp.task('test:auto', ['browserify'], runTests.bind(this, false));
-<% } else { %>
   gulp.task('test', ['scripts'], runTests.bind(this, true));
   gulp.task('test:auto', ['scripts'], runTests.bind(this, false));
-<% } %>
-
 };

--- a/test/template/test-unit-tests.js
+++ b/test/template/test-unit-tests.js
@@ -57,10 +57,25 @@ describe('gulp-angular unit tests template', function () {
     result.should.match(/task\('test', \['scripts'\], runTests\./);
     result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
 
+    model.props.jsPreprocessor.key = 'babel';
+    result = unitTests(model);
+    result.should.match(/task\('test', \['scripts'\], runTests\./);
+    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
+
     model.props.jsPreprocessor.key = 'traceur';
     result = unitTests(model);
-    result.should.match(/task\('test', \['browserify'\], runTests\./);
-    result.should.match(/task\('test:auto', \['browserify'\], runTests\./);
+    result.should.match(/task\('test', \['scripts'\], runTests\./);
+    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
+
+    model.props.jsPreprocessor.key = 'coffee';
+    result = unitTests(model);
+    result.should.match(/task\('test', \['scripts'\], runTests\./);
+    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
+
+    model.props.jsPreprocessor.key = 'typescript';
+    result = unitTests(model);
+    result.should.match(/task\('test', \['scripts'\], runTests\./);
+    result.should.match(/task\('test:auto', \['scripts'\], runTests\./);
   });
 
 });


### PR DESCRIPTION
https://github.com/Swiip/generator-gulp-angular/issues/386#issuecomment-76615762

PhantomJS 2.0 should fixed the error but karma-phantomjs-launcher use PhantomJS 1.9


***
Fix #386 
WIP : use directly `karma` instead of `gulp-karma`. Thanks @eseceve https://github.com/Swiip/generator-gulp-angular/issues/386#issuecomment-76872797