### PR TITLE
Remove the condition on the inclusion of vendor.css

### DIFF
--- a/app/templates/src/_index.html
+++ b/app/templates/src/_index.html
@@ -7,7 +7,6 @@
     <meta name="viewport" content="width=device-width">
     <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
 
-<% if (props.ui.key !== 'none') { %>
     <!-- build:css({<%= props.paths.tmp %>/serve,<%= props.paths.src %>}) styles/vendor.css -->
 <%   if (isVendorStylesPreprocessed) { %>
     <link rel="stylesheet" href="app/vendor.css">
@@ -15,10 +14,9 @@
     <link rel="stylesheet" href="<%= computedPaths.appToBower %>/bower_components/bootstrap/dist/css/bootstrap.css">
 <%   } %>
     <!-- bower:css -->
-    <!-- run `gulp wiredep` to automaticaly populate bower styles dependencies -->
+    <!-- run `gulp inject` to automaticaly populate bower styles dependencies -->
     <!-- endbower -->
     <!-- endbuild -->
-<% } %>
 
     <!-- build:css({<%= props.paths.tmp %>/serve,<%= props.paths.src %>}) styles/app.css -->
     <!-- inject:css -->
@@ -51,7 +49,7 @@
 
     <!-- build:js(<%= props.paths.src %>) scripts/vendor.js -->
     <!-- bower:js -->
-    <!-- run `gulp wiredep` to automaticaly populate bower script dependencies -->
+    <!-- run `gulp inject` to automaticaly populate bower script dependencies -->
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/test/template/test-index-html.js
+++ b/test/template/test-index-html.js
@@ -31,18 +31,12 @@ describe('gulp-angular index js template', function () {
   });
 
   it('should insert the vendor build block depending of data', function() {
-    model.props.ui.key = 'none';
+    model.props.ui.key = 'bootstrap';
     model.props.paths.src = 'src';
     model.props.paths.tmp = 'tmp';
     model.computedPaths.appToBower = 'appToBower';
     model.isVendorStylesPreprocessed = false;
-
     var result = indexHtml(model);
-    result.should.not.match(/<!-- build:css\(.*?\) styles\/vendor\.css -->/);
-    result.should.not.match(/<!-- bower:css/);
-
-    model.props.ui.key = 'bootstrap';
-    result = indexHtml(model);
     result.should.match(/<!-- build:css\({tmp\/serve,src}\) styles\/vendor\.css -->/);
     result.should.match(/<!-- bower:css/);
     result.should.match(/href="appToBower\/bower_components/);


### PR DESCRIPTION
As it is suggested in the #378, it's not because you don't choose an UI framework at the generation that you never will have any Bower CSS dependency.

So I think that we should always have the vendor.css.