### PR TITLE
Add watch on plain old html files

### DIFF
--- a/app/templates/.jshintrc
+++ b/app/templates/.jshintrc
@@ -22,6 +22,7 @@
     "angular": false,
     // Angular Mocks
     "inject": false,
+    "module": false,
     // JASMINE
     "describe": false,
     "it": false,

--- a/app/templates/gulp/_watch.js
+++ b/app/templates/gulp/_watch.js
@@ -1,9 +1,7 @@
 'use strict';
 
 var gulp = require('gulp');
-<% if (props.cssPreprocessor.key === 'none') { %>
 var browserSync = require('browser-sync');
-<% } %>
 
 function isOnlyChange(event) {
   return event.type === 'changed';
@@ -52,6 +50,10 @@ module.exports = function(options) {
 
 <% if (props.htmlPreprocessor.key !== 'none') { %>
     gulp.watch(options.src + '/{app,components}/**/*.<%= props.htmlPreprocessor.extension %>', ['markups']);
+
 <% } %>
+    gulp.watch(options.src + '/{app,components}/**/*.html', function(event) {
+      browserSync.reload(event.path);
+    });
   });
 };


### PR DESCRIPTION
With the new watch, we didn't have any more detection on changes in a templates so I added a watch.

I didn't put an if because even if we have a markup preprocessor, we can also have html templates to watch.

Fix #422 

There is the question of being able to write the index.html with the html preprocessor. It's more complicated and open other questions so I didn't address that.

PS: I had the weaknes of fixing a jshint conf in the same commit...