### PR TITLE
Set karma option autoWatch

### DIFF
--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -70,7 +70,8 @@ module.exports = function(options) {
       karma.server.start({
         configFile: __dirname + '/../karma.conf.js',
         files: files,
-        singleRun: singleRun
+        singleRun: singleRun,
+        autoWatch: !singleRun
       }, done);
     });
   }


### PR DESCRIPTION
In karma, if `singleRun`is define, `autoWatch` is override with false value.

https://github.com/karma-runner/karma/blob/master/lib/config.js#L123

Fix #438 