### PR TITLE
fix(markups): partials not injected into templateCacheHtml.js

### DIFF
--- a/app/templates/gulp/_markups.js
+++ b/app/templates/gulp/_markups.js
@@ -20,7 +20,7 @@ module.exports = function(options) {
       .pipe($.consolidate('handlebars')).on('error', options.errorHandler('Handlebars'))
 <% } %>
       .pipe($.rename(renameToHtml))
-      .pipe(gulp.dest(options.tmp + '/serve/'))
+      .pipe(gulp.dest(options.tmp + '/serve/app/'))
       .pipe(browserSync.reload({ stream: true }));
   });
 };


### PR DESCRIPTION
"gulp markups" builds partials into "options.tmp + '/serve/'"
  ```
  .pipe(gulp.dest(options.tmp + '/serve/'))
  ```
which is ignored by "gulp partials":
  ```
  gulp.task('partials', ['markups'], function () {
    return gulp.src([
      options.src + '/app/**/*.html',
      options.tmp + '/serve/app/**/*.html'     // no templates here
  ```