### PR TITLE
Add dep for task `gulp scripts:watch`

### DIFF
--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -88,7 +88,7 @@ module.exports = function(options) {
     return webpack(false);
   });
 
-  gulp.task('scripts:watch', function (callback) {
+  gulp.task('scripts:watch', ['scripts'], function (callback) {
     return webpack(true, callback);
   });
 <% } %>


### PR DESCRIPTION
With Webpack (ES6) `gulp watch` use 'scripts:watch'  and 'scripts'
These two tasks inject module preloader and loader to `.tmp/serve/app/index.js`

To fix #457 gulp should wait the end of 'scripts' before launch 'scripts:watch'