### PR TITLE
Copy wiredep options

### DIFF
--- a/app/templates/gulp/_inject.js
+++ b/app/templates/gulp/_inject.js
@@ -5,6 +5,7 @@ var gulp = require('gulp');
 var $ = require('gulp-load-plugins')();
 
 var wiredep = require('wiredep').stream;
+var _ = require('lodash');
 
 module.exports = function(options) {
 <% if (props.cssPreprocessor.key !== 'none') { %>
@@ -52,7 +53,7 @@ module.exports = function(options) {
     return gulp.src(options.src + '/*.html')
       .pipe($.inject(injectStyles, injectOptions))
       .pipe($.inject(injectScripts, injectOptions))
-      .pipe(wiredep(options.wiredep))
+      .pipe(wiredep(_.extend({}, options.wiredep)))
       .pipe(gulp.dest(options.tmp + '/serve'));
 
   });

--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -6,6 +6,7 @@ var browserSync = require('browser-sync');
 var $ = require('gulp-load-plugins')();
 
 var wiredep = require('wiredep').stream;
+var _ = require('lodash');
 
 module.exports = function(options) {
   gulp.task('styles', function () {
@@ -52,7 +53,7 @@ module.exports = function(options) {
       .pipe($.inject(injectFiles, injectOptions))
       .pipe(indexFilter.restore())
       .pipe(vendorFilter)
-      .pipe(wiredep(options.wiredep))
+      .pipe(wiredep(_.extend({}, options.wiredep)))
       .pipe(vendorFilter.restore())
 <% if (props.cssPreprocessor.key === 'ruby-sass') { %>
       .pipe($.rubySass(sassOptions)).on('error', options.errorHandler('RubySass'))


### PR DESCRIPTION
As wiredep modify the option object, we have to make a copy on each use to keep the conf unchanged for several uses. 

Fix #476