### PR TITLE
bugfix test:auto

### DIFF
--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -76,7 +76,7 @@ module.exports = function(options) {
   gulp.task('test', ['scripts'], function(done) {
     runTests(true, done);
   });
-  gulp.task('test:auto', ['watch'], function(done) {
+  gulp.task('test:auto', ['scripts'], function(done) {
     runTests(false, done);
   });
 };


### PR DESCRIPTION
run test:auto with 'scripts' taks instead of 'watch'

start a test:auto with watch shows me this error:

>C:\development\spielmacher\spielmacher\gulp\unit-tests.js:39
          .concat(_.pluck(files, 'path'))
           ^
TypeError: Cannot call method 'concat' of undefined
    at C:\development\spielmacher\spielmacher\gulp\unit-tests.js:39:12
    at ConcatStream.<anonymous> (C:\development\spielmacher\spielmacher\nod
ules\concat-stream\index.js:36:43)
    at ConcatStream.EventEmitter.emit (events.js:117:20)
    at finishMaybe (C:\development\spielmacher\spielmacher\node_modules\con


The reason seems to be a problem in wiredep because:

if I debug bowerDeps in untit-test.js:18 it is filled with my index.html context.

I don`t know what is wrong but if i change the 'watch' to 'script' on test:auto
the workaround seems to made it for me.
