### PR TITLE
[Fix #483] Remove Protractor from package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -86,7 +86,6 @@
     "browser-sync-spa": "~1.0.2",
     "http-proxy": "~1.8.0",
     "chalk": "~0.5.1",
-    "protractor": "~1.7.0",
 <% if (qrCode) { %>
     "qrcode-terminal": "~0.9.5",
 <% } %>


### PR DESCRIPTION
This fixes issue #483.

I couldn't get the tests to run, see issue #503, so we'll see if Travis passes, but I didn't see any references to checking the plain package.json in the tests.