### PR TITLE
UI frameworks fixes

### DIFF
--- a/app/src/ui.js
+++ b/app/src/ui.js
@@ -92,7 +92,7 @@ module.exports = function(GulpAngularGenerator) {
       if(this.props.foundationComponents.key !== 'official') {
         this.wiredepExclusions.push('/foundation\\.js/');
       }
-      if(this.props.cssPreprocessor.key !== 'none') {
+      if(this.props.cssPreprocessor.extension === 'scss') {
         this.wiredepExclusions.push('/foundation\\.css/');
       }
     }

--- a/app/src/ui.js
+++ b/app/src/ui.js
@@ -3,16 +3,6 @@
 module.exports = function(GulpAngularGenerator) {
 
   /**
-   * Change the ui framework module name for bootstrap
-   * The Bower package to use is different if sass or another css preprocessor
-   */
-  GulpAngularGenerator.prototype.handleBootstrapVersion = function handleBootstrapVersion() {
-    if(this.props.ui.key.indexOf('bootstrap') !== -1 && this.props.cssPreprocessor.extension !== 'scss') {
-      this.props.ui.name = 'bootstrap';
-    }
-  };
-
-  /**
    * There is 2 ways of dealing with vendor styles
    * - If the vendor styles exist in the css preprocessor chosen,
    *   the best is to include directly the source files

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -26,10 +26,14 @@
     "angular-route": "<%= props.angularVersion %>",
 <% } if (props.router.key === 'ui-router') { %>
     "angular-ui-router": "~0.2.13",
-<% } if(props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'scss') { %>
-    "bootstrap-sass-official": "~3.3.1",
-<% } if(props.ui.key === 'bootstrap' && props.cssPreprocessor.extension !== 'scss') { %>
-    "bootstrap": "~3.3.1",
+<% } if(props.ui.key === 'bootstrap') { %>
+<%   if(props.cssPreprocessor.extension === 'scss') { %>
+    "bootstrap-sass-official": "~3.3.4",
+<%   } else if(props.cssPreprocessor.extension === 'styl') { %>
+    "bootstrap-stylus": "~4.0.4",
+<%   } else { %>
+    "bootstrap": "~3.3.4",
+<%   } %>
 <% } if(props.ui.key === 'foundation') { %>
     "foundation": "~5.5.1",
 <% } if(props.ui.key === 'angular-material') { %>

--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -55,6 +55,8 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/', '../fonts/'))
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'less') { %>
     .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap/fonts/', '../fonts/'))
+<% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'styl') { %>
+    .pipe($.replace('../<%= computedPaths.appToBower %>/bower_components/bootstrap-stylus/fonts/', '../fonts/'))
 <% } %>
     .pipe($.csso())
     .pipe(cssFilter.restore())
@@ -87,7 +89,11 @@ gulp.task('images', function () {
 // Only applies for fonts from bower dependencies
 // Custom fonts are handled by the "other" task
 gulp.task('fonts', function () {
+<% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'styl') { %>
+  return gulp.src($.mainBowerFiles().concat('bower_components/bootstrap-stylus/fonts/*'))
+<% } else { %>
   return gulp.src($.mainBowerFiles())
+<% } %>
     .pipe($.filter('**/*.{eot,svg,ttf,woff,woff2}'))
     .pipe($.flatten())
     .pipe(gulp.dest(path.join(conf.paths.dist, '/fonts/')));

--- a/app/templates/src/app/_angular-material/__angular-material-index.less
+++ b/app/templates/src/app/_angular-material/__angular-material-index.less
@@ -54,7 +54,9 @@ section.jumbotron {
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your less files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your less files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_angular-material/__angular-material-index.scss
+++ b/app/templates/src/app/_angular-material/__angular-material-index.scss
@@ -54,7 +54,9 @@ section.jumbotron {
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your sass files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your sass files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_angular-material/__angular-material-index.styl
+++ b/app/templates/src/app/_angular-material/__angular-material-index.styl
@@ -42,7 +42,9 @@ section
         float right
         width 50px
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your stylus files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your stylus files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_angular-material/__angular-material-vendor.less
+++ b/app/templates/src/app/_angular-material/__angular-material-vendor.less
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   less dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  less dependencies when defined in the bower.json of your dependencies
+ */
 // bower:less
 // endbower

--- a/app/templates/src/app/_angular-material/__angular-material-vendor.scss
+++ b/app/templates/src/app/_angular-material/__angular-material-vendor.scss
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   sass dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  sass dependencies when defined in the bower.json of your dependencies
+ */
 // bower:scss
 // endbower

--- a/app/templates/src/app/_angular-material/__angular-material-vendor.styl
+++ b/app/templates/src/app/_angular-material/__angular-material-vendor.styl
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   stylus dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  stylus dependencies when defined in the bower.json of your dependencies
+ */
 // bower:styl
 // endbower

--- a/app/templates/src/app/_bootstrap/__bootstrap-index.less
+++ b/app/templates/src/app/_bootstrap/__bootstrap-index.less
@@ -13,7 +13,9 @@
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your less files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your less files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_bootstrap/__bootstrap-index.scss
+++ b/app/templates/src/app/_bootstrap/__bootstrap-index.scss
@@ -13,7 +13,9 @@
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your sass files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your sass files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_bootstrap/__bootstrap-index.styl
+++ b/app/templates/src/app/_bootstrap/__bootstrap-index.styl
@@ -10,7 +10,9 @@
   img.pull-right
     width 50px
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your stylus files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your stylus files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_bootstrap/__bootstrap-vendor.less
+++ b/app/templates/src/app/_bootstrap/__bootstrap-vendor.less
@@ -1,6 +1,13 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   less dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  less dependencies when defined in the bower.json of your dependencies
+ */
 // bower:less
 // endbower
 
+/**
+ *  If you want to override some bootstrap variables, you have to change values here.
+ *  The list of variables are listed here bower_components/bootstrap/less/variables.less
+ */
+@navbar-inverse-link-color: #5AADBB;
 @icon-font-path: '../<%= computedPaths.appToBower %>/bower_components/bootstrap/fonts/';

--- a/app/templates/src/app/_bootstrap/__bootstrap-vendor.scss
+++ b/app/templates/src/app/_bootstrap/__bootstrap-vendor.scss
@@ -1,6 +1,13 @@
+/**
+ *  If you want to override some bootstrap variables, you have to change values here.
+ *  The list of variables are listed here bower_components/bootstrap-sass-official/assets/stylesheets/bootstrap/_variables.scss
+ */
+$navbar-inverse-link-color: #5AADBB;
 $icon-font-path: "../<%= computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
 
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   sass dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  sass dependencies when defined in the bower.json of your dependencies
+ */
 // bower:scss
 // endbower

--- a/app/templates/src/app/_bootstrap/__bootstrap-vendor.styl
+++ b/app/templates/src/app/_bootstrap/__bootstrap-vendor.styl
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   stylus dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  stylus dependencies when defined in the bower.json of your dependencies
+ */
 // bower:styl
 // endbower

--- a/app/templates/src/app/_bootstrap/__bootstrap-vendor.styl
+++ b/app/templates/src/app/_bootstrap/__bootstrap-vendor.styl
@@ -1,4 +1,11 @@
 /**
+ *  If you want to override some bootstrap variables, you have to change values here.
+ *  The list of variables are listed here bower_components/bootstrap-stylus/bootstrap/variables.styl
+ */
+$navbar-inverse-link-color = #5AADBB
+$icon-font-path = "../<%= computedPaths.appToBower %>/bower_components/bootstrap-stylus/fonts/"
+
+/**
  *  Do not remove this comments bellow. It's the markers used by wiredep to inject
  *  stylus dependencies when defined in the bower.json of your dependencies
  */

--- a/app/templates/src/app/_foundation/__foundation-index.less
+++ b/app/templates/src/app/_foundation/__foundation-index.less
@@ -18,7 +18,9 @@
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your less files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your less files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_foundation/__foundation-index.scss
+++ b/app/templates/src/app/_foundation/__foundation-index.scss
@@ -18,7 +18,9 @@
   }
 }
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your sass files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your sass files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_foundation/__foundation-index.styl
+++ b/app/templates/src/app/_foundation/__foundation-index.styl
@@ -14,7 +14,9 @@
   img.right
     width 50px
 
-/* Do not remove this comments bellow. It's the markers used by gulp-inject to inject
-   all your stylus files automatically */
+/**
+ *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
+ *  all your stylus files automatically
+ */
 // injector
 // endinjector

--- a/app/templates/src/app/_foundation/__foundation-vendor.less
+++ b/app/templates/src/app/_foundation/__foundation-vendor.less
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   less dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  less dependencies when defined in the bower.json of your dependencies
+ */
 // bower:less
 // endbower

--- a/app/templates/src/app/_foundation/__foundation-vendor.scss
+++ b/app/templates/src/app/_foundation/__foundation-vendor.scss
@@ -1,8 +1,18 @@
-/* The import of foundation is made manually because there is still no links of the
-   sass version in theit bower.json... */
+/**
+ *  If you want to override some foundation settings, you have to change values here.
+ *  The list of settings values are listed here bower_components/foundation/scss/foundation/_settings.scss
+ */
+$topbar-bg-color: #5AADBB;
+
+/**
+ *  The import of foundation is made manually because there is still no links of the
+ *  sass version in their bower.json...
+ */
 @import '../<%= computedPaths.appToBower %>/bower_components/foundation/scss/foundation';
 
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   sass dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  sass dependencies when defined in the bower.json of your dependencies
+ */
 // bower:scss
 // endbower

--- a/app/templates/src/app/_foundation/__foundation-vendor.styl
+++ b/app/templates/src/app/_foundation/__foundation-vendor.styl
@@ -1,4 +1,6 @@
-/* Do not remove this comments bellow. It's the markers used by wiredep to inject
-   stylus dependencies when defined in the bower.json of your dependencies */
+/**
+ *  Do not remove this comments bellow. It's the markers used by wiredep to inject
+ *  stylus dependencies when defined in the bower.json of your dependencies
+ */
 // bower:styl
 // endbower

--- a/test/node/test-ui.js
+++ b/test/node/test-ui.js
@@ -19,32 +19,6 @@ describe('gulp-angular generator ui script', function () {
     generator = new Generator();
   });
 
-  describe('choose bootstrap version depending of the css preprocessor', function () {
-    it('should keep name with sass', function() {
-      generator.props = {
-        ui: {
-          name: 'name-to-change',
-          key: 'bootstrap'
-        },
-        cssPreprocessor: { extension: 'scss' }
-      };
-      generator.handleBootstrapVersion();
-      generator.props.ui.name.should.be.equal('name-to-change');
-    });
-
-    it('should change name to bootstrap with less', function() {
-      generator.props = {
-        ui: {
-          name: 'name-to-change',
-          key: 'bootstrap'
-        },
-        cssPreprocessor: { extension: 'less' }
-      };
-      generator.handleBootstrapVersion();
-      generator.props.ui.name.should.be.equal('bootstrap');
-    });
-  });
-
   describe('set a flag when vendor styles can be preprocessed', function () {
     it('should set true for sass and bootstrap', function() {
       generator.props = {

--- a/test/node/test-ui.js
+++ b/test/node/test-ui.js
@@ -154,16 +154,27 @@ describe('gulp-angular generator ui script', function () {
       generator.wiredepExclusions[0].should.be.equal('/bootstrap\\.js/');
     });
 
-    it('should exclude foundation if foundation', function() {
+    it('should exclude foundation if foundation and sass', function() {
       generator.props = {
         jQuery: { key: 'jquery1' },
         ui: { key: 'foundation' },
         foundationComponents: { key: 'angular-foundation' },
-        cssPreprocessor: { extension: 'less' }
+        cssPreprocessor: { extension: 'scss' }
       };
       generator.computeWiredepExclusions();
       generator.wiredepExclusions[0].should.be.equal('/foundation\\.js/');
       generator.wiredepExclusions[1].should.be.equal('/foundation\\.css/');
+    });
+
+    it('should exclude foundation if foundation and not sass', function() {
+      generator.props = {
+        jQuery: { key: 'jquery1' },
+        ui: { key: 'foundation' },
+        foundationComponents: { key: 'angular-foundation' },
+        cssPreprocessor: { extension: 'notscss' }
+      };
+      generator.computeWiredepExclusions();
+      generator.wiredepExclusions[0].should.be.equal('/foundation\\.js/');
     });
 
     it('should exclude nothing if no ui', function() {

--- a/test/template/test-bower.js
+++ b/test/template/test-bower.js
@@ -148,6 +148,13 @@ describe('gulp-angular bower template', function () {
     result.should.not.match(/foundation/);
     result.should.not.match(/material/);
 
+    model.props.bootstrapComponents.key = 'none';
+    model.props.cssPreprocessor.extension = 'styl';
+    result = bower(model);
+    result.should.match(/bootstrap-stylus/);
+    result.should.not.match(/foundation/);
+    result.should.not.match(/material/);
+
     model.props.ui.key = 'foundation';
     model.props.foundationComponents.key = 'angular-foundation';
     result = bower(model);

--- a/test/template/test-build.js
+++ b/test/template/test-build.js
@@ -45,6 +45,7 @@ describe('gulp-angular build template', function () {
     model.props.cssPreprocessor.extension = 'css';
     var result = build(model);
     result.should.not.match(/\$\.replace/);
+    result.should.match(/mainBowerFiles\(\)\)/);
 
     model.props.ui.key = 'bootstrap';
     model.props.cssPreprocessor.extension = 'scss';
@@ -54,6 +55,11 @@ describe('gulp-angular build template', function () {
     model.props.cssPreprocessor.extension = 'less';
     result = build(model);
     result.should.match(/\$\.replace\('\.\.\/appToBower\/bower_components\/bootstrap\//);
+
+    model.props.cssPreprocessor.extension = 'styl';
+    result = build(model);
+    result.should.match(/\$\.replace\('\.\.\/appToBower\/bower_components\/bootstrap-stylus\//);
+    result.should.match(/mainBowerFiles\(\).concat\('bower_components\/bootstrap-stylus\/fonts\/\*'\)/);
   });
 
   it('should use image min if selected', function() {


### PR DESCRIPTION
- fix #492 foundation.css was excluded from wiredep for all css prepro but it had to be only for sass
- fix #489 illustration of customizings for bootstrap and foundation