### PR TITLE
Adds link to comparison of application project starters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ generator-gulp-angular scaffolds an AngularJS application with a full-featured g
 
 My intention is to create a generator that gives users total control over their development toolbox so they can immediately start projects with their preferred tools, such as specific UI frameworks or JavaScript preprocessors.
 
+This project is one of many things that you can use to get started on a new app.  For a comparison of the options and the trade-offs between them, please visit [this](http://www.dancancro.com/comparison-of-angularjs-application-starters) link.
+
 ## Usage
 
 ### Create your project


### PR DESCRIPTION
This change adds a link in the README to a detailed comparison of projects such as this that someone can use to get started making a new app.  The comparison helps people to make informed decisions about which generators best suit their needs.

I have also added a column to the comparison for generator-gulp-angular.  If you would like to help fill in the details about it, let me know and I will add you to the editor list for the document.