### PR TITLE
Speed up TravisCI build

### DIFF
--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,3 +1,3 @@
 instrumentation:
     default-excludes: false
-    excludes: [node_modules/**, test/*, test/node/**, test/template/**, test/inception/**]
+    excludes: [node_modules/**, test/**]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,39 @@
-sudo: false
-
 language: node_js
-
+sudo: false
 node_js:
   - '0.10'
   - '0.12'
   - iojs
+
+cache:
+  directories:
+    - node_modules
+    - test/tmp/deps/node_modules
 
 matrix:
   fast_finish: true
   allow_failures:
     - node_js: iojs
 
-before_install:
+install:
+  # Check the size of caches
+  - du -sh ./node_modules ./test/tmp/deps/node_modules || true
+  # Disable the spinner, it looks bad on Travis
+  - npm config set spin false
+  - npm install -g npm@latest
+  # Instal npm dependecies and ensure that npm cache is not stale
+  - ./scripts/generator-install-dependencies.sh
+
+before_script:
   - export CHROME_BIN=chromium-browser
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   - gem install sass
-  - npm install -g npm@latest
   - npm install -g bower
   - npm install -g gulp
-  - npm install -g istanbul
+
+script:
+  - npm test
 
 after_success:
   - npm run coveralls

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,6695 @@
+{
+  "name": "generator-gulp-angular",
+  "version": "0.11.0",
+  "dependencies": {
+    "bluebird": {
+      "version": "2.9.25",
+      "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+    },
+    "bower": {
+      "version": "1.4.1",
+      "from": "https://registry.npmjs.org/bower/-/bower-1.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.4.1.tgz",
+      "dependencies": {
+        "abbrev": {
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+        },
+        "archy": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+        },
+        "bower-config": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.6.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-endpoint-parser": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bower-endpoint-parser/-/bower-endpoint-parser-0.2.2.tgz"
+        },
+        "bower-json": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/bower-json/-/bower-json-0.4.0.tgz",
+          "dependencies": {
+            "deep-extend": {
+              "version": "0.2.11",
+              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "intersect": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/intersect/-/intersect-0.0.3.tgz"
+            }
+          }
+        },
+        "bower-logger": {
+          "version": "0.2.2",
+          "from": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz",
+          "resolved": "https://registry.npmjs.org/bower-logger/-/bower-logger-0.2.2.tgz"
+        },
+        "bower-registry-client": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/bower-registry-client/-/bower-registry-client-0.3.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "lru-cache": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.3.1.tgz"
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.0.12",
+                      "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.10.0",
+                          "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "request-replay": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/request-replay/-/request-replay-0.2.0.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            }
+          }
+        },
+        "cardinal": {
+          "version": "0.4.4",
+          "from": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "resolved": "https://registry.npmjs.org/cardinal/-/cardinal-0.4.4.tgz",
+          "dependencies": {
+            "redeyed": {
+              "version": "0.4.4",
+              "from": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "resolved": "https://registry.npmjs.org/redeyed/-/redeyed-0.4.4.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+                }
+              }
+            },
+            "ansicolors": {
+              "version": "0.2.1",
+              "from": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.2.1.tgz"
+            }
+          }
+        },
+        "chmodr": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/chmodr/-/chmodr-0.1.0.tgz"
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "dependencies": {
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "osenv": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+            }
+          }
+        },
+        "decompress-zip": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.1.0.tgz",
+          "dependencies": {
+            "binary": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+              "dependencies": {
+                "chainsaw": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+                  "dependencies": {
+                    "traverse": {
+                      "version": "0.3.9",
+                      "from": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+                      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz"
+                    }
+                  }
+                },
+                "buffers": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz"
+                }
+              }
+            },
+            "mkpath": {
+              "version": "0.1.0",
+              "from": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "touch": {
+              "version": "0.0.3",
+              "from": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+              "dependencies": {
+                "nopt": {
+                  "version": "1.0.10",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz"
+                }
+              }
+            }
+          }
+        },
+        "fstream": {
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.2.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "github": {
+          "version": "0.2.4",
+          "from": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/github/-/github-0.2.4.tgz",
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.7",
+          "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+        },
+        "handlebars": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.3.7",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.0",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "chalk": {
+              "version": "0.5.1",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "mute-stream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.5.3",
+          "from": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "lodash.debounce": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-root": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+        },
+        "junk": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/junk/-/junk-1.0.1.tgz"
+        },
+        "lockfile": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.1.tgz"
+        },
+        "lru-cache": {
+          "version": "2.6.4",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "mout": {
+          "version": "0.11.0",
+          "from": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz",
+          "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.0.tgz"
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        },
+        "p-throttler": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/p-throttler/-/p-throttler-0.1.1.tgz",
+          "dependencies": {
+            "q": {
+              "version": "0.9.7",
+              "from": "https://registry.npmjs.org/q/-/q-0.9.7.tgz",
+              "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+            }
+          }
+        },
+        "promptly": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/promptly/-/promptly-0.2.0.tgz",
+          "dependencies": {
+            "read": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "q": {
+          "version": "1.4.1",
+          "from": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "request": {
+          "version": "2.53.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.53.0.tgz",
+          "dependencies": {
+            "bl": {
+              "version": "0.9.4",
+              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "caseless": {
+              "version": "0.9.0",
+              "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "form-data": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.12",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.10.0",
+                  "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                }
+              }
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "qs": {
+              "version": "2.3.3",
+              "from": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "tough-cookie": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.6.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+            },
+            "hawk": {
+              "version": "2.3.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.13.0",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                },
+                "boom": {
+                  "version": "2.7.1",
+                  "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.4",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            },
+            "combined-stream": {
+              "version": "0.0.7",
+              "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            }
+          }
+        },
+        "request-progress": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+          "dependencies": {
+            "throttleit": {
+              "version": "0.0.2",
+              "from": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+            }
+          }
+        },
+        "retry": {
+          "version": "0.6.1",
+          "from": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.4",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+        },
+        "shell-quote": {
+          "version": "1.4.3",
+          "from": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.4.3.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            },
+            "array-filter": {
+              "version": "0.0.1",
+              "from": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz"
+            },
+            "array-reduce": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz"
+            },
+            "array-map": {
+              "version": "0.0.0",
+              "from": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz"
+            }
+          }
+        },
+        "stringify-object": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-1.0.1.tgz"
+        },
+        "tar-fs": {
+          "version": "1.5.1",
+          "from": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.5.1.tgz",
+          "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.5.1.tgz",
+          "dependencies": {
+            "pump": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "tar-stream": {
+              "version": "1.1.5",
+              "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+              "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                },
+                "end-of-stream": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "tmp": {
+          "version": "0.0.24",
+          "from": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz",
+          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+        },
+        "update-notifier": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+          "dependencies": {
+            "is-npm": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+            },
+            "latest-version": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+              "dependencies": {
+                "package-json": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+                  "dependencies": {
+                    "got": {
+                      "version": "2.9.2",
+                      "from": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                      "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+                      "dependencies": {
+                        "duplexify": {
+                          "version": "3.4.0",
+                          "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                          "dependencies": {
+                            "end-of-stream": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "infinity-agent": {
+                          "version": "2.0.3",
+                          "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                        },
+                        "is-stream": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                        },
+                        "lowercase-keys": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                        },
+                        "nested-error-stacks": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+                        },
+                        "object-assign": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                        },
+                        "prepend-http": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                        },
+                        "read-all-stream": {
+                          "version": "2.1.2",
+                          "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "statuses": {
+                          "version": "1.2.1",
+                          "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                        },
+                        "timed-out": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "registry-url": {
+                      "version": "3.0.3",
+                      "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+                      "dependencies": {
+                        "rc": {
+                          "version": "1.0.3",
+                          "from": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.3",
+                              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "semver-diff": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                }
+              }
+            },
+            "string-length": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+              "dependencies": {
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "which": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "chai": {
+      "version": "2.3.0",
+      "from": "https://registry.npmjs.org/chai/-/chai-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-2.3.0.tgz",
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.0.tgz"
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "from": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "chai-as-promised": {
+      "version": "5.0.0",
+      "from": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-5.0.0.tgz"
+    },
+    "chalk": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "has-ansi": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+        }
+      }
+    },
+    "commander": {
+      "version": "2.8.1",
+      "from": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+      "dependencies": {
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+        }
+      }
+    },
+    "coveralls": {
+      "version": "2.11.2",
+      "from": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.2.tgz",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.2.tgz",
+      "dependencies": {
+        "js-yaml": {
+          "version": "3.0.1",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.4.0.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+            }
+          }
+        },
+        "lcov-parse": {
+          "version": "0.0.6",
+          "from": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.6.tgz"
+        },
+        "log-driver": {
+          "version": "1.2.4",
+          "from": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz",
+          "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.4.tgz"
+        },
+        "request": {
+          "version": "2.40.0",
+          "from": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.40.0.tgz",
+          "dependencies": {
+            "qs": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-1.0.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+            },
+            "forever-agent": {
+              "version": "0.5.2",
+              "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+            },
+            "node-uuid": {
+              "version": "1.4.3",
+              "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+            },
+            "tough-cookie": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+            },
+            "form-data": {
+              "version": "0.1.4",
+              "from": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "async": {
+                  "version": "0.9.2",
+                  "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+            },
+            "http-signature": {
+              "version": "0.10.1",
+              "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.1.5",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                },
+                "asn1": {
+                  "version": "0.1.11",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                },
+                "ctype": {
+                  "version": "0.5.3",
+                  "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+            },
+            "hawk": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.9.1",
+                  "from": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                },
+                "boom": {
+                  "version": "0.4.2",
+                  "from": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.2.2",
+                  "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                },
+                "sntp": {
+                  "version": "0.2.4",
+                  "from": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                }
+              }
+            },
+            "aws-sign2": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.4",
+              "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "cross-spawn": {
+      "version": "0.4.0",
+      "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.4.0.tgz",
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.6.4",
+          "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+        },
+        "spawn-sync": {
+          "version": "1.0.11",
+          "from": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.11.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.4.8",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "os-shim": {
+              "version": "0.1.2",
+              "from": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.2.tgz"
+            },
+            "try-thread-sleep": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/try-thread-sleep/-/try-thread-sleep-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/try-thread-sleep/-/try-thread-sleep-1.0.0.tgz",
+              "dependencies": {
+                "thread-sleep": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/thread-sleep/-/thread-sleep-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/thread-sleep/-/thread-sleep-1.0.3.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.8.4",
+                      "from": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.2",
+                      "from": "node-pre-gyp@>=0.6.2 <0.7.0",
+                      "resolved": "http://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.2.tgz",
+                      "dependencies": {
+                        "nopt": {
+                          "version": "3.0.1",
+                          "from": "nopt@~3.0.1",
+                          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.1.tgz",
+                          "dependencies": {
+                            "abbrev": {
+                              "version": "1.0.5",
+                              "from": "abbrev@1",
+                              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+                            }
+                          }
+                        },
+                        "npmlog": {
+                          "version": "0.1.1",
+                          "from": "npmlog@~0.1.1",
+                          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-0.1.1.tgz",
+                          "dependencies": {
+                            "ansi": {
+                              "version": "0.3.0",
+                              "from": "ansi@~0.3.0",
+                              "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                            }
+                          }
+                        },
+                        "request": {
+                          "version": "2.51.0",
+                          "from": "request@2.x",
+                          "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.3",
+                              "from": "bl@~0.9.0",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+                              "dependencies": {
+                                "readable-stream": {
+                                  "version": "1.0.33",
+                                  "from": "readable-stream@~1.0.26",
+                                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                                  "dependencies": {
+                                    "core-util-is": {
+                                      "version": "1.0.1",
+                                      "from": "core-util-is@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                    },
+                                    "isarray": {
+                                      "version": "0.0.1",
+                                      "from": "isarray@0.0.1",
+                                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                    },
+                                    "string_decoder": {
+                                      "version": "0.10.31",
+                                      "from": "string_decoder@~0.10.x",
+                                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                    },
+                                    "inherits": {
+                                      "version": "2.0.1",
+                                      "from": "inherits@~2.0.1",
+                                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "caseless": {
+                              "version": "0.8.0",
+                              "from": "caseless@~0.8.0",
+                              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                            },
+                            "forever-agent": {
+                              "version": "0.5.2",
+                              "from": "forever-agent@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                            },
+                            "form-data": {
+                              "version": "0.2.0",
+                              "from": "form-data@~0.2.0",
+                              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                              "dependencies": {
+                                "async": {
+                                  "version": "0.9.0",
+                                  "from": "async@~0.9.0",
+                                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+                                },
+                                "mime-types": {
+                                  "version": "2.0.7",
+                                  "from": "mime-types@~2.0.3",
+                                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+                                  "dependencies": {
+                                    "mime-db": {
+                                      "version": "1.5.0",
+                                      "from": "mime-db@~1.5.0",
+                                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "json-stringify-safe": {
+                              "version": "5.0.0",
+                              "from": "json-stringify-safe@~5.0.0",
+                              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+                            },
+                            "mime-types": {
+                              "version": "1.0.2",
+                              "from": "mime-types@~1.0.1",
+                              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                            },
+                            "node-uuid": {
+                              "version": "1.4.2",
+                              "from": "node-uuid@~1.4.0",
+                              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+                            },
+                            "qs": {
+                              "version": "2.3.3",
+                              "from": "qs@~2.3.1",
+                              "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                            },
+                            "tunnel-agent": {
+                              "version": "0.4.0",
+                              "from": "tunnel-agent@~0.4.0",
+                              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                            },
+                            "tough-cookie": {
+                              "version": "0.12.1",
+                              "from": "tough-cookie@>=0.12.0",
+                              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+                              "dependencies": {
+                                "punycode": {
+                                  "version": "1.3.2",
+                                  "from": "punycode@>=0.2.0",
+                                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                                }
+                              }
+                            },
+                            "http-signature": {
+                              "version": "0.10.1",
+                              "from": "http-signature@~0.10.0",
+                              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                              "dependencies": {
+                                "assert-plus": {
+                                  "version": "0.1.5",
+                                  "from": "assert-plus@^0.1.5",
+                                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                                },
+                                "asn1": {
+                                  "version": "0.1.11",
+                                  "from": "asn1@0.1.11",
+                                  "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                                },
+                                "ctype": {
+                                  "version": "0.5.3",
+                                  "from": "ctype@0.5.3",
+                                  "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                                }
+                              }
+                            },
+                            "oauth-sign": {
+                              "version": "0.5.0",
+                              "from": "oauth-sign@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                            },
+                            "hawk": {
+                              "version": "1.1.1",
+                              "from": "hawk@1.1.1",
+                              "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                              "dependencies": {
+                                "hoek": {
+                                  "version": "0.9.1",
+                                  "from": "hoek@0.9.x",
+                                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                                },
+                                "boom": {
+                                  "version": "0.4.2",
+                                  "from": "boom@0.4.x",
+                                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                                },
+                                "cryptiles": {
+                                  "version": "0.2.2",
+                                  "from": "cryptiles@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                                },
+                                "sntp": {
+                                  "version": "0.2.4",
+                                  "from": "sntp@0.2.x",
+                                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                                }
+                              }
+                            },
+                            "aws-sign2": {
+                              "version": "0.5.0",
+                              "from": "aws-sign2@~0.5.0",
+                              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                            },
+                            "stringstream": {
+                              "version": "0.0.4",
+                              "from": "stringstream@~0.0.4",
+                              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                            },
+                            "combined-stream": {
+                              "version": "0.0.7",
+                              "from": "combined-stream@~0.0.5",
+                              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                              "dependencies": {
+                                "delayed-stream": {
+                                  "version": "0.0.5",
+                                  "from": "delayed-stream@0.0.5",
+                                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "semver": {
+                          "version": "4.2.0",
+                          "from": "semver@~4.2.0",
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
+                        },
+                        "tar": {
+                          "version": "1.0.3",
+                          "from": "tar@~1.0.2",
+                          "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                          "dependencies": {
+                            "block-stream": {
+                              "version": "0.0.7",
+                              "from": "block-stream@*",
+                              "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                            },
+                            "fstream": {
+                              "version": "1.0.3",
+                              "from": "fstream@^1.0.2",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.3.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-pack": {
+                          "version": "2.0.0",
+                          "from": "tar-pack@~2.0.0",
+                          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+                          "dependencies": {
+                            "uid-number": {
+                              "version": "0.0.3",
+                              "from": "uid-number@0.0.3",
+                              "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
+                            },
+                            "once": {
+                              "version": "1.1.1",
+                              "from": "once@~1.1.1",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
+                            },
+                            "debug": {
+                              "version": "0.7.4",
+                              "from": "debug@~0.7.2",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                            },
+                            "fstream": {
+                              "version": "0.1.31",
+                              "from": "fstream@~0.1.22",
+                              "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "3.0.5",
+                                  "from": "graceful-fs@3",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "tar": {
+                              "version": "0.1.20",
+                              "from": "tar@~0.1.17",
+                              "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+                              "dependencies": {
+                                "block-stream": {
+                                  "version": "0.0.7",
+                                  "from": "block-stream@*",
+                                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "fstream-ignore": {
+                              "version": "0.0.7",
+                              "from": "fstream-ignore@0.0.7",
+                              "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+                              "dependencies": {
+                                "minimatch": {
+                                  "version": "0.2.14",
+                                  "from": "minimatch@~0.2.0",
+                                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                                  "dependencies": {
+                                    "lru-cache": {
+                                      "version": "2.5.0",
+                                      "from": "lru-cache@2",
+                                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+                                    },
+                                    "sigmund": {
+                                      "version": "1.0.0",
+                                      "from": "sigmund@~1.0.0",
+                                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@2",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "readable-stream@~1.0.2",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "core-util-is@~1.0.0",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "isarray@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "string_decoder@~0.10.x",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@~2.0.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@1.2",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            }
+                          }
+                        },
+                        "mkdirp": {
+                          "version": "0.5.0",
+                          "from": "mkdirp@~0.5.0",
+                          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.8",
+                              "from": "minimist@0.0.8",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                            }
+                          }
+                        },
+                        "rc": {
+                          "version": "0.5.5",
+                          "from": "rc@~0.5.1",
+                          "resolved": "https://registry.npmjs.org/rc/-/rc-0.5.5.tgz",
+                          "dependencies": {
+                            "minimist": {
+                              "version": "0.0.10",
+                              "from": "minimist@~0.0.7",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                            },
+                            "deep-extend": {
+                              "version": "0.2.11",
+                              "from": "deep-extend@~0.2.5",
+                              "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                            },
+                            "strip-json-comments": {
+                              "version": "0.1.3",
+                              "from": "strip-json-comments@0.1.x",
+                              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                            },
+                            "ini": {
+                              "version": "1.3.2",
+                              "from": "ini@~1.3.0",
+                              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
+                            }
+                          }
+                        },
+                        "rimraf": {
+                          "version": "2.2.8",
+                          "from": "rimraf@~2.2.8",
+                          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "ejs": {
+      "version": "2.3.1",
+      "from": "https://registry.npmjs.org/ejs/-/ejs-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.3.1.tgz"
+    },
+    "fixture-stdout": {
+      "version": "0.2.1",
+      "from": "https://registry.npmjs.org/fixture-stdout/-/fixture-stdout-0.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/fixture-stdout/-/fixture-stdout-0.2.1.tgz"
+    },
+    "istanbul": {
+      "version": "0.3.14",
+      "from": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.14.tgz",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.3.14.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.1.0",
+          "from": "https://registry.npmjs.org/esprima/-/esprima-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.1.0.tgz"
+        },
+        "escodegen": {
+          "version": "1.6.1",
+          "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            },
+            "esutils": {
+              "version": "1.1.6",
+              "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+            },
+            "esprima": {
+              "version": "1.2.5",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "optionator": {
+              "version": "0.5.0",
+              "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                  "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.1",
+                  "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                },
+                "levn": {
+                  "version": "0.2.5",
+                  "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                  "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "1.0.6",
+                  "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "handlebars": {
+          "version": "3.0.0",
+          "from": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-3.0.0.tgz",
+          "dependencies": {
+            "optimist": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.3.6",
+              "from": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz"
+                }
+              }
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz"
+        },
+        "fileset": {
+          "version": "0.1.5",
+          "from": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.5.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.4.0",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+        },
+        "abbrev": {
+          "version": "1.0.6",
+          "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.3",
+          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+        },
+        "resolve": {
+          "version": "1.1.6",
+          "from": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+        },
+        "js-yaml": {
+          "version": "3.3.1",
+          "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+            }
+          }
+        },
+        "once": {
+          "version": "1.3.2",
+          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+          "dependencies": {
+            "wrappy": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "js-beautify": {
+      "version": "1.5.5",
+      "from": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.5.tgz",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.5.5.tgz",
+      "dependencies": {
+        "config-chain": {
+          "version": "1.1.8",
+          "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+          "dependencies": {
+            "proto-list": {
+              "version": "1.2.4",
+              "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+              "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+            },
+            "ini": {
+              "version": "1.3.3",
+              "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+              "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+            }
+          }
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.9.1",
+      "from": "lodash@>=3.9.1 <3.10.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "mocha": {
+      "version": "2.2.5",
+      "from": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
+        "debug": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.8.1",
+          "from": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz",
+          "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+        },
+        "jade": {
+          "version": "0.26.3",
+          "from": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "0.6.1",
+              "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.2.1",
+          "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
+        }
+      }
+    },
+    "mocha-lcov-reporter": {
+      "version": "0.0.2",
+      "from": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/mocha-lcov-reporter/-/mocha-lcov-reporter-0.0.2.tgz"
+    },
+    "mz": {
+      "version": "1.3.0",
+      "from": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+      "dependencies": {
+        "native-or-bluebird": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+        },
+        "thenify": {
+          "version": "3.1.0",
+          "from": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
+        },
+        "thenify-all": {
+          "version": "1.6.0",
+          "from": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+        }
+      }
+    },
+    "recursive-readdir": {
+      "version": "1.2.1",
+      "from": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-1.2.1.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "sinon": {
+      "version": "1.14.1",
+      "from": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.14.1.tgz",
+      "dependencies": {
+        "formatio": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz",
+          "dependencies": {
+            "samsam": {
+              "version": "1.1.2",
+              "from": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "lolex": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.1.0.tgz"
+        }
+      }
+    },
+    "sinon-chai": {
+      "version": "2.7.0",
+      "from": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.7.0.tgz",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.7.0.tgz"
+    },
+    "slash": {
+      "version": "1.0.0",
+      "from": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
+    "underscore.string": {
+      "version": "3.0.3",
+      "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.0.3.tgz"
+    },
+    "wrench": {
+      "version": "1.5.8",
+      "from": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
+    },
+    "yeoman-generator": {
+      "version": "0.20.1",
+      "from": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.20.1.tgz",
+      "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-0.20.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "class-extend": {
+          "version": "0.1.1",
+          "from": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/class-extend/-/class-extend-0.1.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "cli-table": {
+          "version": "0.3.1",
+          "from": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+            }
+          }
+        },
+        "dargs": {
+          "version": "4.0.1",
+          "from": "https://registry.npmjs.org/dargs/-/dargs-4.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-4.0.1.tgz",
+          "dependencies": {
+            "number-is-nan": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "detect-conflict": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.0.tgz"
+        },
+        "diff": {
+          "version": "1.4.0",
+          "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+        },
+        "download": {
+          "version": "4.1.2",
+          "from": "https://registry.npmjs.org/download/-/download-4.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/download/-/download-4.1.2.tgz",
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.4.8",
+              "from": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "typedarray": {
+                  "version": "0.0.6",
+                  "from": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+                  "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "each-async": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+              "dependencies": {
+                "onetime": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                }
+              }
+            },
+            "filenamify": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/filenamify/-/filenamify-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-1.1.0.tgz",
+              "dependencies": {
+                "filename-reserved-regex": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-1.0.0.tgz"
+                },
+                "strip-outer": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.0.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    }
+                  }
+                },
+                "trim-repeated": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+                  "dependencies": {
+                    "escape-string-regexp": {
+                      "version": "1.0.3",
+                      "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "got": {
+              "version": "2.9.2",
+              "from": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+              "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+              "dependencies": {
+                "duplexify": {
+                  "version": "3.4.0",
+                  "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "infinity-agent": {
+                  "version": "2.0.3",
+                  "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                },
+                "is-stream": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                },
+                "lowercase-keys": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                },
+                "nested-error-stacks": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+                },
+                "prepend-http": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                },
+                "read-all-stream": {
+                  "version": "2.1.2",
+                  "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                },
+                "timed-out": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                }
+              }
+            },
+            "gulp-decompress": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/gulp-decompress/-/gulp-decompress-1.0.2.tgz",
+              "dependencies": {
+                "archive-type": {
+                  "version": "2.1.0",
+                  "from": "https://registry.npmjs.org/archive-type/-/archive-type-2.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/archive-type/-/archive-type-2.1.0.tgz",
+                  "dependencies": {
+                    "file-type": {
+                      "version": "2.6.0",
+                      "from": "https://registry.npmjs.org/file-type/-/file-type-2.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.6.0.tgz"
+                    }
+                  }
+                },
+                "decompress": {
+                  "version": "2.3.0",
+                  "from": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                  "resolved": "https://registry.npmjs.org/decompress/-/decompress-2.3.0.tgz",
+                  "dependencies": {
+                    "buffer-to-vinyl": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/buffer-to-vinyl/-/buffer-to-vinyl-1.0.0.tgz",
+                      "dependencies": {
+                        "file-type": {
+                          "version": "2.6.0",
+                          "from": "https://registry.npmjs.org/file-type/-/file-type-2.6.0.tgz",
+                          "resolved": "https://registry.npmjs.org/file-type/-/file-type-2.6.0.tgz"
+                        },
+                        "uuid": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "decompress-tar": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-3.1.0.tgz",
+                      "dependencies": {
+                        "is-tar": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-tar/-/is-tar-1.0.0.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.5",
+                          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-tarbz2": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decompress-tarbz2/-/decompress-tarbz2-3.1.0.tgz",
+                      "dependencies": {
+                        "is-bzip2": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-bzip2/-/is-bzip2-1.0.0.tgz"
+                        },
+                        "seek-bzip": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.4.tgz",
+                          "dependencies": {
+                            "commander": {
+                              "version": "2.4.0",
+                              "from": "https://registry.npmjs.org/commander/-/commander-2.4.0.tgz",
+                              "resolved": "https://registry.npmjs.org/commander/-/commander-2.4.0.tgz"
+                            }
+                          }
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.5",
+                          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-targz": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/decompress-targz/-/decompress-targz-3.1.0.tgz",
+                      "dependencies": {
+                        "is-gzip": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "tar-stream": {
+                          "version": "1.1.5",
+                          "from": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
+                          "dependencies": {
+                            "bl": {
+                              "version": "0.9.4",
+                              "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                              "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz"
+                            },
+                            "end-of-stream": {
+                              "version": "1.1.0",
+                              "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
+                              "dependencies": {
+                                "once": {
+                                  "version": "1.3.2",
+                                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                                  "dependencies": {
+                                    "wrappy": {
+                                      "version": "1.0.1",
+                                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "readable-stream": {
+                              "version": "1.0.33",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "decompress-unzip": {
+                      "version": "3.2.2",
+                      "from": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.2.2.tgz",
+                      "resolved": "https://registry.npmjs.org/decompress-unzip/-/decompress-unzip-3.2.2.tgz",
+                      "dependencies": {
+                        "is-zip": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-zip/-/is-zip-1.0.0.tgz"
+                        },
+                        "read-all-stream": {
+                          "version": "2.1.2",
+                          "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "stat-mode": {
+                          "version": "0.2.1",
+                          "from": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz",
+                          "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-0.2.1.tgz"
+                        },
+                        "strip-dirs": {
+                          "version": "1.1.1",
+                          "from": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/strip-dirs/-/strip-dirs-1.1.1.tgz",
+                          "dependencies": {
+                            "is-absolute": {
+                              "version": "0.1.7",
+                              "from": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+                              "dependencies": {
+                                "is-relative": {
+                                  "version": "0.1.3",
+                                  "from": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                                }
+                              }
+                            },
+                            "is-natural-number": {
+                              "version": "2.0.0",
+                              "from": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/is-natural-number/-/is-natural-number-2.0.0.tgz"
+                            },
+                            "minimist": {
+                              "version": "1.1.1",
+                              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                            },
+                            "sum-up": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/sum-up/-/sum-up-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "yauzl": {
+                          "version": "2.3.1",
+                          "from": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.3.1.tgz",
+                          "dependencies": {
+                            "fd-slicer": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+                            },
+                            "pend": {
+                              "version": "1.2.0",
+                              "from": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "vinyl-assign": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/vinyl-assign/-/vinyl-assign-1.1.0.tgz"
+                    }
+                  }
+                },
+                "gulp-util": {
+                  "version": "3.0.4",
+                  "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+                  "dependencies": {
+                    "array-differ": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+                    },
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    },
+                    "beeper": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
+                    },
+                    "lodash._reescape": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+                    },
+                    "lodash._reevaluate": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+                    },
+                    "lodash._reinterpolate": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+                    },
+                    "lodash.template": {
+                      "version": "3.6.0",
+                      "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.0.tgz",
+                      "dependencies": {
+                        "lodash._basecopy": {
+                          "version": "3.0.1",
+                          "from": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                        },
+                        "lodash._basetostring": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+                        },
+                        "lodash._basevalues": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+                        },
+                        "lodash._isiterateecall": {
+                          "version": "3.0.8",
+                          "from": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz"
+                        },
+                        "lodash.escape": {
+                          "version": "3.0.0",
+                          "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+                        },
+                        "lodash.keys": {
+                          "version": "3.1.0",
+                          "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
+                          "dependencies": {
+                            "lodash._getnative": {
+                              "version": "3.9.0",
+                              "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                            },
+                            "lodash.isarguments": {
+                              "version": "3.0.3",
+                              "from": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                            },
+                            "lodash.isarray": {
+                              "version": "3.0.3",
+                              "from": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                            }
+                          }
+                        },
+                        "lodash.restparam": {
+                          "version": "3.6.1",
+                          "from": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                        },
+                        "lodash.templatesettings": {
+                          "version": "3.1.0",
+                          "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "multipipe": {
+                      "version": "0.1.2",
+                      "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                      "dependencies": {
+                        "duplexer2": {
+                          "version": "0.0.2",
+                          "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                          "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                          "dependencies": {
+                            "readable-stream": {
+                              "version": "1.1.13",
+                              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "dependencies": {
+                                "core-util-is": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "isarray": {
+                                  "version": "0.0.1",
+                                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                                },
+                                "string_decoder": {
+                                  "version": "0.10.31",
+                                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "replace-ext": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "gulp-rename": {
+              "version": "1.2.2",
+              "from": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+            },
+            "is-url": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/is-url/-/is-url-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.0.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "read-all-stream": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-1.0.2.tgz"
+            },
+            "stream-combiner2": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.0.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "through2": {
+                  "version": "0.5.1",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            },
+            "vinyl-fs": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+              "dependencies": {
+                "duplexify": {
+                  "version": "3.4.0",
+                  "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                  "dependencies": {
+                    "end-of-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                      "dependencies": {
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-stream": {
+                  "version": "4.1.1",
+                  "from": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "ordered-read-streams": {
+                      "version": "0.1.0",
+                      "from": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                    },
+                    "glob2base": {
+                      "version": "0.0.12",
+                      "from": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                      "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                      "dependencies": {
+                        "find-index": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "unique-stream": {
+                      "version": "2.0.2",
+                      "from": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                      "dependencies": {
+                        "es6-set": {
+                          "version": "0.1.1",
+                          "from": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                          "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                          "dependencies": {
+                            "d": {
+                              "version": "0.1.1",
+                              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                            },
+                            "es5-ext": {
+                              "version": "0.10.7",
+                              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-iterator": {
+                              "version": "0.1.3",
+                              "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                              "dependencies": {
+                                "es6-symbol": {
+                                  "version": "2.0.1",
+                                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                                }
+                              }
+                            },
+                            "es6-symbol": {
+                              "version": "0.1.1",
+                              "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                            },
+                            "event-emitter": {
+                              "version": "0.3.3",
+                              "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                            }
+                          }
+                        },
+                        "through2-filter": {
+                          "version": "1.4.1",
+                          "from": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                          "dependencies": {
+                            "xtend": {
+                              "version": "4.0.0",
+                              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "glob-watcher": {
+                  "version": "0.0.8",
+                  "from": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+                  "dependencies": {
+                    "gaze": {
+                      "version": "0.5.1",
+                      "from": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                      "dependencies": {
+                        "globule": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                          "dependencies": {
+                            "lodash": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                            },
+                            "glob": {
+                              "version": "3.1.21",
+                              "from": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                              "dependencies": {
+                                "graceful-fs": {
+                                  "version": "1.2.3",
+                                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+                                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                                },
+                                "inherits": {
+                                  "version": "1.0.0",
+                                  "from": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "minimatch": {
+                              "version": "0.2.14",
+                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                              "dependencies": {
+                                "lru-cache": {
+                                  "version": "2.6.4",
+                                  "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                                },
+                                "sigmund": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "merge-stream": {
+                  "version": "0.1.7",
+                  "from": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz",
+                  "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz"
+                },
+                "strip-bom": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                  "dependencies": {
+                    "first-chunk-stream": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                    },
+                    "is-utf8": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ware": {
+              "version": "1.3.0",
+              "from": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/ware/-/ware-1.3.0.tgz",
+              "dependencies": {
+                "wrap-fn": {
+                  "version": "0.1.4",
+                  "from": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                  "resolved": "https://registry.npmjs.org/wrap-fn/-/wrap-fn-0.1.4.tgz",
+                  "dependencies": {
+                    "co": {
+                      "version": "3.1.0",
+                      "from": "https://registry.npmjs.org/co/-/co-3.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/co/-/co-3.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "github-username": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/github-username/-/github-username-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/github-username/-/github-username-2.0.0.tgz",
+          "dependencies": {
+            "gh-got": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/gh-got/-/gh-got-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-1.1.0.tgz",
+              "dependencies": {
+                "got": {
+                  "version": "3.2.0",
+                  "from": "https://registry.npmjs.org/got/-/got-3.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/got/-/got-3.2.0.tgz",
+                  "dependencies": {
+                    "duplexify": {
+                      "version": "3.4.0",
+                      "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+                      "dependencies": {
+                        "end-of-stream": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                          "dependencies": {
+                            "once": {
+                              "version": "1.3.2",
+                              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "infinity-agent": {
+                      "version": "2.0.3",
+                      "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+                      "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+                    },
+                    "is-stream": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+                    },
+                    "lowercase-keys": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+                    },
+                    "nested-error-stacks": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+                    },
+                    "prepend-http": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+                    },
+                    "read-all-stream": {
+                      "version": "2.1.2",
+                      "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    },
+                    "timed-out": {
+                      "version": "2.0.0",
+                      "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "5.0.6",
+          "from": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.6.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gruntfile-editor": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/gruntfile-editor/-/gruntfile-editor-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/gruntfile-editor/-/gruntfile-editor-1.0.0.tgz",
+          "dependencies": {
+            "ast-query": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/ast-query/-/ast-query-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/ast-query/-/ast-query-1.0.1.tgz",
+              "dependencies": {
+                "escodegen": {
+                  "version": "1.6.1",
+                  "from": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.6.1.tgz",
+                  "dependencies": {
+                    "estraverse": {
+                      "version": "1.9.3",
+                      "from": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+                      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+                    },
+                    "esutils": {
+                      "version": "1.1.6",
+                      "from": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+                    },
+                    "esprima": {
+                      "version": "1.2.5",
+                      "from": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz",
+                      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+                    },
+                    "optionator": {
+                      "version": "0.5.0",
+                      "from": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
+                      "dependencies": {
+                        "prelude-ls": {
+                          "version": "1.1.2",
+                          "from": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+                          "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                        },
+                        "deep-is": {
+                          "version": "0.1.3",
+                          "from": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+                          "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                        },
+                        "wordwrap": {
+                          "version": "0.0.3",
+                          "from": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                        },
+                        "type-check": {
+                          "version": "0.3.1",
+                          "from": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz",
+                          "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.1.tgz"
+                        },
+                        "levn": {
+                          "version": "0.2.5",
+                          "from": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
+                          "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
+                        },
+                        "fast-levenshtein": {
+                          "version": "1.0.6",
+                          "from": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz",
+                          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.0.6.tgz"
+                        }
+                      }
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                },
+                "traverse": {
+                  "version": "0.6.6",
+                  "from": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+                  "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "html-wiring": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/html-wiring/-/html-wiring-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/html-wiring/-/html-wiring-1.1.0.tgz",
+          "dependencies": {
+            "cheerio": {
+              "version": "0.19.0",
+              "from": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+              "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.19.0.tgz",
+              "dependencies": {
+                "css-select": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.0.0.tgz",
+                  "dependencies": {
+                    "css-what": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/css-what/-/css-what-1.0.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.4.3",
+                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.4.3.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.3.0",
+                          "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                        }
+                      }
+                    },
+                    "boolbase": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+                    },
+                    "nth-check": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                },
+                "htmlparser2": {
+                  "version": "3.8.2",
+                  "from": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+                  "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+                  "dependencies": {
+                    "domhandler": {
+                      "version": "2.3.0",
+                      "from": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                    },
+                    "domutils": {
+                      "version": "1.5.1",
+                      "from": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz"
+                    },
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "entities": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                    }
+                  }
+                },
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.4",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "cli-width": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+            },
+            "figures": {
+              "version": "1.3.5",
+              "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "istextorbinary": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+          "dependencies": {
+            "textextensions": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
+            },
+            "binaryextensions": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
+            }
+          }
+        },
+        "mem-fs-editor": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-2.0.0.tgz",
+          "dependencies": {
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mime": {
+          "version": "1.3.4",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+        },
+        "nopt": {
+          "version": "3.0.2",
+          "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.6",
+              "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "pretty-bytes": {
+          "version": "1.0.4",
+          "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "read-chunk": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-1.0.1.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.4",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "run-async": {
+          "version": "0.1.0",
+          "from": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+          "dependencies": {
+            "once": {
+              "version": "1.3.2",
+              "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.4.0",
+          "from": "https://registry.npmjs.org/shelljs/-/shelljs-0.4.0.tgz",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.4.0.tgz"
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "xdg-basedir": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+        },
+        "yeoman-assert": {
+          "version": "2.0.0",
+          "from": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-assert/-/yeoman-assert-2.0.0.tgz"
+        },
+        "yeoman-environment": {
+          "version": "1.2.5",
+          "from": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.2.5.tgz",
+          "dependencies": {
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "globby": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+              "dependencies": {
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "dependencies": {
+                    "array-uniq": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            },
+            "grouped-queue": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                },
+                "setimmediate": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz"
+                }
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+            },
+            "mem-fs": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.0.tgz",
+              "dependencies": {
+                "vinyl": {
+                  "version": "0.4.6",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "dependencies": {
+                    "clone": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                    },
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                },
+                "vinyl-file": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.7",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                    },
+                    "strip-bom": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                      "dependencies": {
+                        "first-chunk-stream": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                        },
+                        "is-utf8": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "untildify": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/untildify/-/untildify-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.0.0.tgz"
+            }
+          }
+        },
+        "yeoman-welcome": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-welcome/-/yeoman-welcome-1.0.1.tgz"
+        }
+      }
+    },
+    "yo": {
+      "version": "1.4.6",
+      "from": "https://registry.npmjs.org/yo/-/yo-1.4.6.tgz",
+      "resolved": "https://registry.npmjs.org/yo/-/yo-1.4.6.tgz",
+      "dependencies": {
+        "array-uniq": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+        },
+        "async": {
+          "version": "0.9.2",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "configstore": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-0.3.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            },
+            "js-yaml": {
+              "version": "3.3.1",
+              "from": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.3.1.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.2.tgz",
+                  "dependencies": {
+                    "sprintf-js": {
+                      "version": "1.0.2",
+                      "from": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz",
+                      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.2.tgz"
+                    }
+                  }
+                },
+                "esprima": {
+                  "version": "2.2.0",
+                  "from": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.2.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "osenv": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+            },
+            "uuid": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz"
+            },
+            "xdg-basedir": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-1.0.1.tgz"
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "0.2.9",
+          "from": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+            }
+          }
+        },
+        "figures": {
+          "version": "1.3.5",
+          "from": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+        },
+        "findup": {
+          "version": "0.1.5",
+          "from": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+          "resolved": "https://registry.npmjs.org/findup/-/findup-0.1.5.tgz",
+          "dependencies": {
+            "colors": {
+              "version": "0.6.2",
+              "from": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+            },
+            "commander": {
+              "version": "2.1.0",
+              "from": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.1.0.tgz"
+            }
+          }
+        },
+        "fullname": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/fullname/-/fullname-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/fullname/-/fullname-1.1.0.tgz",
+          "dependencies": {
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.8",
+                  "from": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.6",
+                      "from": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.1",
+                  "from": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                },
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "got": {
+          "version": "2.9.2",
+          "from": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+          "resolved": "https://registry.npmjs.org/got/-/got-2.9.2.tgz",
+          "dependencies": {
+            "duplexify": {
+              "version": "3.4.0",
+              "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "infinity-agent": {
+              "version": "2.0.3",
+              "from": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
+            },
+            "is-stream": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.0.1.tgz"
+            },
+            "lowercase-keys": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz"
+            },
+            "nested-error-stacks": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-1.0.0.tgz"
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "prepend-http": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.1.tgz"
+            },
+            "read-all-stream": {
+              "version": "2.1.2",
+              "from": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+              "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-2.1.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "statuses": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+            },
+            "timed-out": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
+            }
+          }
+        },
+        "humanize-string": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/humanize-string/-/humanize-string-1.0.1.tgz",
+          "dependencies": {
+            "decamelize": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+            }
+          }
+        },
+        "inquirer": {
+          "version": "0.8.4",
+          "from": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.4.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+            },
+            "cli-width": {
+              "version": "1.0.1",
+              "from": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-1.0.1.tgz"
+            },
+            "readline2": {
+              "version": "0.1.1",
+              "from": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.1.tgz",
+              "dependencies": {
+                "mute-stream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+                }
+              }
+            },
+            "rx": {
+              "version": "2.5.2",
+              "from": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz",
+              "resolved": "https://registry.npmjs.org/rx/-/rx-2.5.2.tgz"
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "https://registry.npmjs.org/through/-/through-2.3.7.tgz",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "insight": {
+          "version": "0.5.3",
+          "from": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "resolved": "https://registry.npmjs.org/insight/-/insight-0.5.3.tgz",
+          "dependencies": {
+            "lodash.debounce": {
+              "version": "3.1.0",
+              "from": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-3.1.0.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0",
+                  "from": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "os-name": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/os-name/-/os-name-1.0.3.tgz",
+              "dependencies": {
+                "osx-release": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/osx-release/-/osx-release-1.0.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    }
+                  }
+                },
+                "win-release": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.0.0.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.55.0",
+              "from": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.12",
+                  "from": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.13.0",
+                      "from": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.7.1",
+                      "from": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.1.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.7.0",
+                  "from": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "dependencies": {
+                    "is-my-json-valid": {
+                      "version": "2.12.0",
+                      "from": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "tough-cookie": {
+              "version": "0.12.1",
+              "from": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "meow": {
+          "version": "3.1.0",
+          "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.1",
+              "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            }
+          }
+        },
+        "npm-keyword": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/npm-keyword/-/npm-keyword-1.1.1.tgz",
+          "dependencies": {
+            "registry-url": {
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+              "dependencies": {
+                "rc": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        },
+        "package-json": {
+          "version": "1.1.0",
+          "from": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/package-json/-/package-json-1.1.0.tgz",
+          "dependencies": {
+            "registry-url": {
+              "version": "3.0.3",
+              "from": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.0.3.tgz",
+              "dependencies": {
+                "rc": {
+                  "version": "1.0.3",
+                  "from": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/rc/-/rc-1.0.3.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.2.11",
+                      "from": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "0.1.3",
+                      "from": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.3",
+                      "from": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "root-check": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
+          "dependencies": {
+            "downgrade-root": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/downgrade-root/-/downgrade-root-1.1.0.tgz",
+              "dependencies": {
+                "default-uid": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/default-uid/-/default-uid-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/default-uid/-/default-uid-1.0.0.tgz"
+                },
+                "is-root": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+                }
+              }
+            },
+            "sudo-block": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/sudo-block/-/sudo-block-1.2.0.tgz",
+              "dependencies": {
+                "is-docker": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-docker/-/is-docker-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-1.0.0.tgz"
+                },
+                "is-root": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/is-root/-/is-root-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "sort-on": {
+          "version": "1.2.0",
+          "from": "https://registry.npmjs.org/sort-on/-/sort-on-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/sort-on/-/sort-on-1.2.0.tgz",
+          "dependencies": {
+            "dot-prop": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-2.0.0.tgz"
+            }
+          }
+        },
+        "string-length": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+          "dependencies": {
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "titleize": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/titleize/-/titleize-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.0.tgz"
+        },
+        "update-notifier": {
+          "version": "0.3.2",
+          "from": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-0.3.2.tgz",
+          "dependencies": {
+            "is-npm": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz"
+            },
+            "latest-version": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-1.0.0.tgz"
+            },
+            "semver-diff": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.0.0.tgz",
+              "dependencies": {
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "user-home": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+        },
+        "yeoman-character": {
+          "version": "1.0.1",
+          "from": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-character/-/yeoman-character-1.0.1.tgz",
+          "dependencies": {
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "yeoman-doctor": {
+          "version": "1.3.2",
+          "from": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-1.3.2.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-1.3.2.tgz",
+          "dependencies": {
+            "each-async": {
+              "version": "1.1.1",
+              "from": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+              "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+              "dependencies": {
+                "onetime": {
+                  "version": "1.0.0",
+                  "from": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+                },
+                "set-immediate-shim": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                }
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+            },
+            "object-values": {
+              "version": "1.0.0",
+              "from": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz"
+            },
+            "twig": {
+              "version": "0.7.2",
+              "from": "https://registry.npmjs.org/twig/-/twig-0.7.2.tgz",
+              "resolved": "https://registry.npmjs.org/twig/-/twig-0.7.2.tgz",
+              "dependencies": {
+                "walk": {
+                  "version": "2.3.9",
+                  "from": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+                  "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.9.tgz",
+                  "dependencies": {
+                    "foreachasync": {
+                      "version": "3.0.0",
+                      "from": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/foreachasync/-/foreachasync-3.0.0.tgz"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "yeoman-environment": {
+          "version": "1.2.5",
+          "from": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.2.5.tgz",
+          "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-1.2.5.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "diff": {
+              "version": "1.4.0",
+              "from": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "globby": {
+              "version": "1.2.0",
+              "from": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+              "dependencies": {
+                "array-union": {
+                  "version": "1.0.1",
+                  "from": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+                  "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz"
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            },
+            "grouped-queue": {
+              "version": "0.3.0",
+              "from": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-0.3.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                },
+                "setimmediate": {
+                  "version": "1.0.2",
+                  "from": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz",
+                  "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.2.tgz"
+                }
+              }
+            },
+            "log-symbols": {
+              "version": "1.0.2",
+              "from": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+              "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+            },
+            "mem-fs": {
+              "version": "1.1.0",
+              "from": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.0.tgz",
+              "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.1.0.tgz",
+              "dependencies": {
+                "through2": {
+                  "version": "0.6.5",
+                  "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                  "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "xtend": {
+                      "version": "4.0.0",
+                      "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.4.6",
+                  "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+                  "dependencies": {
+                    "clone": {
+                      "version": "0.2.0",
+                      "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
+                      "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                    },
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                },
+                "vinyl-file": {
+                  "version": "1.1.1",
+                  "from": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
+                  "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "3.0.7",
+                      "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                    },
+                    "strip-bom": {
+                      "version": "1.0.0",
+                      "from": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+                      "dependencies": {
+                        "first-chunk-stream": {
+                          "version": "1.0.0",
+                          "from": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
+                          "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                        },
+                        "is-utf8": {
+                          "version": "0.2.0",
+                          "from": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz",
+                          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            },
+            "untildify": {
+              "version": "2.0.0",
+              "from": "https://registry.npmjs.org/untildify/-/untildify-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/untildify/-/untildify-2.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "yosay": {
+      "version": "1.0.3",
+      "from": "https://registry.npmjs.org/yosay/-/yosay-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/yosay/-/yosay-1.0.3.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+        },
+        "ansi-styles": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+        },
+        "minimist": {
+          "version": "1.1.1",
+          "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+        },
+        "pad-component": {
+          "version": "0.0.1",
+          "from": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz"
+        },
+        "string-length": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz"
+        },
+        "strip-ansi": {
+          "version": "2.0.1",
+          "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz"
+        },
+        "taketalk": {
+          "version": "1.0.0",
+          "from": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/taketalk/-/taketalk-1.0.0.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            }
+          }
+        },
+        "word-wrap": {
+          "version": "1.0.3",
+          "from": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.0.3.tgz"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "generator-gulp-angular",
   "version": "0.11.0",
   "preferGlobal": true,
-  "description": "Yeoman generator for AngularJS with GulpJS",
+  "description": "Yeoman generator for AngularJS with Gulp",
   "keywords": "yeoman-generator, angular, gulp, restangular, ui-router, bootstrap, angular-material, foundation, sass, less, es6, babel, traceur, typescript, coffeescript, jade, haml, webpack, jshint",
   "license": "MIT",
   "author": "Matthieu Lux & Mehdy Dara",
@@ -16,44 +16,38 @@
   "main": "app/index.js",
   "repository": "Swiip/generator-gulp-angular",
   "scripts": {
-    "pretest": "node test/template-cli.js prepare && node test/template-cli.js deps && cd test/tmp/deps && npm install && bower install",
-    "test": "mocha test/** -ig protractor",
-    "coveralls": "istanbul cover ./node_modules/mocha/bin/_mocha -- test/node test/template -ig protractor && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js",
-    "cover": "istanbul cover ./node_modules/mocha/bin/_mocha -- test/node test/template"
-  },
-  "config": {
-    "blanket": {
-      "pattern": "app"
-    }
+    "pretest": "./scripts/prepare-test.sh",
+    "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- test/node test/template && ./node_modules/.bin/mocha test/inception/test-inception.js -ig protractor",
+    "coveralls": "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "dependencies": {
     "chalk": "~1.0.0",
-    "lodash": "~3.7.0",
+    "lodash": "~3.9.1",
     "slash": "~1.0.0",
     "underscore.string": "~3.0.3",
     "yeoman-generator": "~0.20.1",
     "yosay": "~1.0.3"
   },
   "devDependencies": {
+    "bluebird": "~2.9.25",
     "bower": "~1.4.1",
     "chai": "~2.3.0",
     "chai-as-promised": "~5.0.0",
     "commander": "~2.8.1",
     "coveralls": "~2.11.2",
     "cross-spawn": "~0.4.0",
+    "ejs": "~2.3.1",
     "fixture-stdout": "~0.2.1",
     "istanbul": "~0.3.14",
     "js-beautify": "~1.5.5",
     "mkdirp": "^0.5.1",
     "mocha": "~2.2.5",
     "mocha-lcov-reporter": "0.0.2",
+    "mz": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
     "recursive-readdir": "~1.2.1",
     "sinon": "~1.14.1",
     "sinon-chai": "~2.7.0",
-    "wrench": "1.5.8",
-    "ejs": "~2.3.1",
-    "mz": "~1.3.0",
-    "bluebird": "~2.9.25"
+    "wrench": "1.5.8"
   },
   "peerDependencies": {
     "yo": ">=1.0.0"

--- a/scripts/generator-install-dependencies.sh
+++ b/scripts/generator-install-dependencies.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+SHRINKWRAP_FILE=npm-shrinkwrap.json
+SHRINKWRAP_CACHED_FILE=node_modules/npm-shrinkwrap.cached.json
+
+if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
+  echo 'No shrinkwrap changes detected. npm install will be skipped...';
+else
+  echo 'Blowing away node_modules and reinstalling npm dependencies...'
+  rm -rf node_modules
+  npm install
+  cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
+  echo 'npm install successful!'
+fi

--- a/scripts/prepare-test.sh
+++ b/scripts/prepare-test.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+node test/template-cli.js prepare
+
+node test/template-cli.js deps
+
+cd test/tmp/deps
+
+SHRINKWRAP_FILE=../../npm-shrinkwrap.json
+SHRINKWRAP_CACHED_FILE=node_modules/npm-shrinkwrap.cached.json
+
+if diff -q $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE; then
+  echo 'No shrinkwrap changes detected. npm install will be skipped...';
+else
+  echo 'Blowing away node_modules and reinstalling npm dependencies...'
+  rm -rf node_modules
+  npm install
+  cp $SHRINKWRAP_FILE $SHRINKWRAP_CACHED_FILE
+  echo 'npm install successful!'
+fi
+
+bower install

--- a/test/npm-shrinkwrap.json
+++ b/test/npm-shrinkwrap.json
@@ -1,0 +1,13914 @@
+{
+  "name": "appName",
+  "version": "0.0.0",
+  "dependencies": {
+    "babel-core": {
+      "version": "4.7.16",
+      "from": "babel-core@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-4.7.16.tgz",
+      "dependencies": {
+        "acorn-babel": {
+          "version": "0.11.1-38",
+          "from": "acorn-babel@0.11.1-38",
+          "resolved": "https://registry.npmjs.org/acorn-babel/-/acorn-babel-0.11.1-38.tgz"
+        },
+        "ast-types": {
+          "version": "0.7.6",
+          "from": "ast-types@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz"
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.8.1",
+          "from": "commander@>=2.6.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "0.5.1",
+          "from": "convert-source-map@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.5.1.tgz"
+        },
+        "core-js": {
+          "version": "0.6.1",
+          "from": "core-js@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.6.1.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.1",
+              "from": "ms@0.7.1",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+            }
+          }
+        },
+        "detect-indent": {
+          "version": "3.0.1",
+          "from": "detect-indent@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+            }
+          }
+        },
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+        },
+        "esutils": {
+          "version": "1.1.6",
+          "from": "esutils@>=1.1.6 <2.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz"
+        },
+        "fs-readdir-recursive": {
+          "version": "0.1.2",
+          "from": "fs-readdir-recursive@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
+        },
+        "globals": {
+          "version": "6.4.1",
+          "from": "globals@>=6.2.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
+        },
+        "is-integer": {
+          "version": "1.0.4",
+          "from": "is-integer@>=1.0.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.4.tgz",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.1",
+              "from": "is-finite@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.0",
+                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                }
+              }
+            },
+            "is-nan": {
+              "version": "1.0.1",
+              "from": "is-nan@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-nan/-/is-nan-1.0.1.tgz"
+            }
+          }
+        },
+        "js-tokens": {
+          "version": "1.0.0",
+          "from": "js-tokens@1.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.0.tgz"
+        },
+        "leven": {
+          "version": "1.0.2",
+          "from": "leven@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
+        },
+        "line-numbers": {
+          "version": "0.2.0",
+          "from": "line-numbers@0.2.0",
+          "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
+          "dependencies": {
+            "left-pad": {
+              "version": "0.0.3",
+              "from": "left-pad@0.0.3",
+              "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
+            }
+          }
+        },
+        "output-file-sync": {
+          "version": "1.1.0",
+          "from": "output-file-sync@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.0.tgz",
+          "dependencies": {
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.0",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+        },
+        "private": {
+          "version": "0.1.6",
+          "from": "private@>=0.1.6 <0.2.0",
+          "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+        },
+        "regenerator-babel": {
+          "version": "0.8.13-2",
+          "from": "regenerator-babel@0.8.13-2",
+          "resolved": "https://registry.npmjs.org/regenerator-babel/-/regenerator-babel-0.8.13-2.tgz",
+          "dependencies": {
+            "commoner": {
+              "version": "0.10.1",
+              "from": "commoner@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.1.tgz",
+              "dependencies": {
+                "q": {
+                  "version": "1.1.2",
+                  "from": "q@>=1.1.2 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+                },
+                "recast": {
+                  "version": "0.9.18",
+                  "from": "recast@>=0.9.5 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.9.18.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "10001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=10001.1.0-dev-harmony-fb <10001.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-10001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.43",
+                      "from": "source-map@>=0.1.40 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "ast-types": {
+                      "version": "0.6.16",
+                      "from": "ast-types@>=0.6.1 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.6.16.tgz"
+                    }
+                  }
+                },
+                "commander": {
+                  "version": "2.5.1",
+                  "from": "commander@>=2.5.0 <2.6.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+                },
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.4 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "glob": {
+                  "version": "4.2.2",
+                  "from": "glob@>=4.2.1 <4.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.2.2.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "1.0.0",
+                      "from": "minimatch@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "install": {
+                  "version": "0.1.8",
+                  "from": "install@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/install/-/install-0.1.8.tgz"
+                },
+                "iconv-lite": {
+                  "version": "0.4.8",
+                  "from": "iconv-lite@>=0.4.5 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz"
+                }
+              }
+            },
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.6 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "regexpu": {
+          "version": "1.1.2",
+          "from": "regexpu@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.2.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.10.12",
+              "from": "recast@>=0.10.1 <0.11.0",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "14001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@>=14001.1.0-dev-harmony-fb <14001.2.0",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-14001.1.0-dev-harmony-fb.tgz"
+                }
+              }
+            },
+            "regenerate": {
+              "version": "1.2.1",
+              "from": "regenerate@>=1.2.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "from": "regjsgen@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+            },
+            "regjsparser": {
+              "version": "0.1.4",
+              "from": "regjsparser@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
+              "dependencies": {
+                "jsesc": {
+                  "version": "0.5.0",
+                  "from": "jsesc@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "repeating": {
+          "version": "1.1.2",
+          "from": "repeating@>=1.1.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+          "dependencies": {
+            "is-finite": {
+              "version": "1.0.1",
+              "from": "is-finite@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+              "dependencies": {
+                "number-is-nan": {
+                  "version": "1.0.0",
+                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                }
+              }
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shebang-regex": {
+          "version": "1.0.0",
+          "from": "shebang-regex@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "slash@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.4.2",
+          "from": "source-map@>=0.4.0 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "source-map-support": {
+          "version": "0.2.10",
+          "from": "source-map-support@>=0.2.9 <0.3.0",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.32",
+              "from": "source-map@0.1.32",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "to-fast-properties": {
+          "version": "1.0.1",
+          "from": "to-fast-properties@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
+        },
+        "trim-right": {
+          "version": "1.0.0",
+          "from": "trim-right@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.0.tgz"
+        }
+      }
+    },
+    "babel-loader": {
+      "version": "4.0.0",
+      "from": "babel-loader@>=4.0.0 <4.1.0",
+      "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-4.0.0.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.9",
+          "from": "loader-utils@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.0.2",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "browser-sync": {
+      "version": "2.1.6",
+      "from": "browser-sync@>=2.1.4 <2.2.0",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.1.6.tgz",
+      "dependencies": {
+        "async-each-series": {
+          "version": "0.1.1",
+          "from": "async-each-series@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
+        },
+        "browser-sync-client": {
+          "version": "1.0.2",
+          "from": "browser-sync-client@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-1.0.2.tgz"
+        },
+        "browser-sync-ui": {
+          "version": "0.4.11",
+          "from": "browser-sync-ui@>=0.4.7 <0.5.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.4.11.tgz",
+          "dependencies": {
+            "angular": {
+              "version": "1.3.15",
+              "from": "angular@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.15.tgz"
+            },
+            "angular-route": {
+              "version": "1.3.15",
+              "from": "angular-route@>=1.3.8 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.3.15.tgz"
+            },
+            "angular-sanitize": {
+              "version": "1.3.15",
+              "from": "angular-sanitize@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.15.tgz"
+            },
+            "angular-touch": {
+              "version": "1.3.15",
+              "from": "angular-touch@>=1.3.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.3.15.tgz"
+            },
+            "connect-history-api-fallback": {
+              "version": "0.0.5",
+              "from": "connect-history-api-fallback@0.0.5",
+              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+            },
+            "weinre": {
+              "version": "2.0.0-pre-I0Z7U9OV",
+              "from": "weinre@>=2.0.0-pre-I0Z7U9OV <3.0.0",
+              "resolved": "https://registry.npmjs.org/weinre/-/weinre-2.0.0-pre-I0Z7U9OV.tgz",
+              "dependencies": {
+                "express": {
+                  "version": "2.5.11",
+                  "from": "express@>=2.5.0 <2.6.0",
+                  "resolved": "https://registry.npmjs.org/express/-/express-2.5.11.tgz",
+                  "dependencies": {
+                    "connect": {
+                      "version": "1.9.2",
+                      "from": "connect@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/connect/-/connect-1.9.2.tgz",
+                      "dependencies": {
+                        "formidable": {
+                          "version": "1.0.17",
+                          "from": "formidable@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.17.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.4",
+                      "from": "mime@1.2.4",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.4.tgz"
+                    },
+                    "qs": {
+                      "version": "0.4.2",
+                      "from": "qs@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.4.2.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.6",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                    }
+                  }
+                },
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "connect": {
+          "version": "3.3.5",
+          "from": "connect@>=3.3.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-3.3.5.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.1.3",
+              "from": "debug@>=2.1.3 <2.2.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.3.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.0",
+                  "from": "ms@0.7.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.3.4",
+              "from": "finalhandler@0.3.4",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.4.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "on-finished": {
+                  "version": "2.2.1",
+                  "from": "on-finished@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "dev-ip": {
+          "version": "1.0.1",
+          "from": "dev-ip@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz"
+        },
+        "easy-extender": {
+          "version": "2.3.1",
+          "from": "easy-extender@>=2.2.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.1.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "eazy-logger": {
+          "version": "2.1.2",
+          "from": "eazy-logger@>=2.1.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-2.1.2.tgz",
+          "dependencies": {
+            "opt-merger": {
+              "version": "1.1.0",
+              "from": "opt-merger@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/opt-merger/-/opt-merger-1.1.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                }
+              }
+            },
+            "tfunk": {
+              "version": "3.0.1",
+              "from": "tfunk@>=3.0.1 <4.0.0",
+              "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.0.1.tgz",
+              "dependencies": {
+                "object-path": {
+                  "version": "0.9.2",
+                  "from": "object-path@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "emitter-steward": {
+          "version": "0.0.1",
+          "from": "emitter-steward@>=0.0.1 <0.0.2",
+          "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-0.0.1.tgz"
+        },
+        "foxy": {
+          "version": "10.1.2",
+          "from": "foxy@>=10.0.2 <11.0.0",
+          "resolved": "https://registry.npmjs.org/foxy/-/foxy-10.1.2.tgz",
+          "dependencies": {
+            "cookie": {
+              "version": "0.1.3",
+              "from": "cookie@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+            },
+            "http-proxy": {
+              "version": "1.11.1",
+              "from": "http-proxy@>=1.9.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "1.1.0",
+                  "from": "eventemitter3@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.0.tgz"
+                },
+                "requires-port": {
+                  "version": "0.0.0",
+                  "from": "requires-port@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob-watcher": {
+          "version": "0.0.7",
+          "from": "glob-watcher@>=0.0.7 <0.0.8",
+          "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.7.tgz",
+          "dependencies": {
+            "gaze": {
+              "version": "0.5.1",
+              "from": "gaze@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "dependencies": {
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "lodash@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.0",
+                          "from": "inherits@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "immutable": {
+          "version": "3.7.3",
+          "from": "immutable@>=3.4.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.3.tgz"
+        },
+        "localtunnel": {
+          "version": "1.5.0",
+          "from": "localtunnel@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.5.0.tgz",
+          "dependencies": {
+            "request": {
+              "version": "2.11.4",
+              "from": "request@2.11.4",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.11.4.tgz",
+              "dependencies": {
+                "form-data": {
+                  "version": "0.0.3",
+                  "from": "form-data",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.3",
+                      "from": "combined-stream@0.0.3",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.1.9",
+                      "from": "async@0.1.9"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.2.7",
+                  "from": "mime"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.4",
+              "from": "optimist@0.3.4",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.4.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@0.7.4",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            }
+          }
+        },
+        "meow": {
+          "version": "3.1.0",
+          "from": "meow@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "1.0.0",
+              "from": "camelcase-keys@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "camelcase@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "map-obj": {
+                  "version": "1.0.1",
+                  "from": "map-obj@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                }
+              }
+            },
+            "indent-string": {
+              "version": "1.2.1",
+              "from": "indent-string@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "repeating": {
+                  "version": "1.1.2",
+                  "from": "repeating@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.1",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.0",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            }
+          }
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "opn@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+        },
+        "portscanner": {
+          "version": "1.0.0",
+          "from": "portscanner@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+            }
+          }
+        },
+        "resp-modifier": {
+          "version": "2.1.0",
+          "from": "resp-modifier@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-2.1.0.tgz",
+          "dependencies": {
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "serve-index": {
+          "version": "1.6.4",
+          "from": "serve-index@>=1.6.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.4.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.2.7",
+              "from": "accepts@>=1.2.7 <1.3.0",
+              "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.7.tgz",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.5.3",
+                  "from": "negotiator@0.5.3",
+                  "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.5.2",
+              "from": "batch@0.5.2",
+              "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.0.12",
+              "from": "mime-types@>=2.0.11 <2.1.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.10.0",
+                  "from": "mime-db@>=1.10.0 <1.11.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.9.3",
+          "from": "serve-static@>=1.4.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz",
+          "dependencies": {
+            "escape-html": {
+              "version": "1.0.1",
+              "from": "escape-html@1.0.1",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "send": {
+              "version": "0.12.3",
+              "from": "send@0.12.3",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "2.2.0",
+                  "from": "debug@>=2.2.0 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+                },
+                "depd": {
+                  "version": "1.0.1",
+                  "from": "depd@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+                },
+                "destroy": {
+                  "version": "1.0.3",
+                  "from": "destroy@1.0.3",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                },
+                "etag": {
+                  "version": "1.6.0",
+                  "from": "etag@>=1.6.0 <1.7.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                },
+                "fresh": {
+                  "version": "0.2.4",
+                  "from": "fresh@0.2.4",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                },
+                "on-finished": {
+                  "version": "2.2.1",
+                  "from": "on-finished@>=2.2.1 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.0",
+                      "from": "ee-first@1.1.0",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                    }
+                  }
+                },
+                "range-parser": {
+                  "version": "1.0.2",
+                  "from": "range-parser@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            }
+          }
+        },
+        "socket.io": {
+          "version": "1.3.5",
+          "from": "socket.io@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.5.tgz",
+          "dependencies": {
+            "engine.io": {
+              "version": "1.5.1",
+              "from": "engine.io@1.5.1",
+              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.3",
+                  "from": "debug@1.0.3",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "ws": {
+                  "version": "0.5.0",
+                  "from": "ws@0.5.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.4.3",
+                      "from": "nan@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    },
+                    "ultron": {
+                      "version": "1.0.1",
+                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                    }
+                  }
+                },
+                "engine.io-parser": {
+                  "version": "1.2.1",
+                  "from": "engine.io-parser@1.2.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                  "dependencies": {
+                    "after": {
+                      "version": "0.8.1",
+                      "from": "after@0.8.1",
+                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6",
+                      "from": "arraybuffer.slice@0.0.6",
+                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                    },
+                    "base64-arraybuffer": {
+                      "version": "0.1.2",
+                      "from": "base64-arraybuffer@0.1.2",
+                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                    },
+                    "blob": {
+                      "version": "0.0.2",
+                      "from": "blob@0.0.2",
+                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                    },
+                    "has-binary": {
+                      "version": "0.1.5",
+                      "from": "has-binary@0.1.5",
+                      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "utf8": {
+                      "version": "2.0.0",
+                      "from": "utf8@2.0.0",
+                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                    }
+                  }
+                },
+                "base64id": {
+                  "version": "0.1.0",
+                  "from": "base64id@0.1.0",
+                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.4",
+              "from": "socket.io-parser@2.2.4",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "benchmark@1.0.0",
+                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                }
+              }
+            },
+            "socket.io-client": {
+              "version": "1.3.5",
+              "from": "socket.io-client@1.3.5",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.5.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "engine.io-client": {
+                  "version": "1.5.1",
+                  "from": "engine.io-client@1.5.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
+                  "dependencies": {
+                    "has-cors": {
+                      "version": "1.0.3",
+                      "from": "has-cors@1.0.3",
+                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                      "dependencies": {
+                        "global": {
+                          "version": "2.0.1",
+                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.4.31",
+                      "from": "ws@0.4.31",
+                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "0.6.1",
+                          "from": "commander@>=0.6.1 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                        },
+                        "nan": {
+                          "version": "0.3.2",
+                          "from": "nan@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                        },
+                        "tinycolor": {
+                          "version": "0.0.1",
+                          "from": "tinycolor@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                        },
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        }
+                      }
+                    },
+                    "xmlhttprequest": {
+                      "version": "1.5.0",
+                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+                      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                    },
+                    "engine.io-parser": {
+                      "version": "1.2.1",
+                      "from": "engine.io-parser@1.2.1",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                      "dependencies": {
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "after@0.8.1",
+                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "arraybuffer.slice@0.0.6",
+                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                        },
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "base64-arraybuffer@0.1.2",
+                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                        },
+                        "blob": {
+                          "version": "0.0.2",
+                          "from": "blob@0.0.2",
+                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                        },
+                        "has-binary": {
+                          "version": "0.1.5",
+                          "from": "has-binary@0.1.5",
+                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                          "dependencies": {
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            }
+                          }
+                        },
+                        "utf8": {
+                          "version": "2.0.0",
+                          "from": "utf8@2.0.0",
+                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "1.0.4",
+                      "from": "debug@1.0.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "parseuri": {
+                      "version": "0.0.4",
+                      "from": "parseuri@0.0.4",
+                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parsejson": {
+                      "version": "0.0.1",
+                      "from": "parsejson@0.0.1",
+                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parseqs": {
+                      "version": "0.0.2",
+                      "from": "parseqs@0.0.2",
+                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "component-inherit": {
+                      "version": "0.0.3",
+                      "from": "component-inherit@0.0.3",
+                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                    }
+                  }
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "component-bind@1.0.0",
+                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "object-component@0.0.3",
+                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                },
+                "has-binary": {
+                  "version": "0.1.6",
+                  "from": "has-binary@0.1.6",
+                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "parseuri": {
+                  "version": "0.0.2",
+                  "from": "parseuri@0.0.2",
+                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-array": {
+                  "version": "0.1.3",
+                  "from": "to-array@0.1.3",
+                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                },
+                "backo2": {
+                  "version": "1.0.2",
+                  "from": "backo2@1.0.2",
+                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "from": "socket.io-adapter@0.3.1",
+              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "from": "debug@1.0.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "from": "socket.io-parser@2.2.2",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "benchmark@1.0.0",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    }
+                  }
+                },
+                "object-keys": {
+                  "version": "1.0.1",
+                  "from": "object-keys@1.0.1",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                }
+              }
+            },
+            "has-binary-data": {
+              "version": "0.1.3",
+              "from": "has-binary-data@0.1.3",
+              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "2.1.0",
+              "from": "debug@2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "ua-parser-js": {
+          "version": "0.7.7",
+          "from": "ua-parser-js@>=0.7.3 <0.8.0",
+          "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.7.tgz"
+        }
+      }
+    },
+    "browser-sync-spa": {
+      "version": "1.0.2",
+      "from": "browser-sync-spa@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/browser-sync-spa/-/browser-sync-spa-1.0.2.tgz",
+      "dependencies": {
+        "connect-history-api-fallback": {
+          "version": "0.0.5",
+          "from": "connect-history-api-fallback@0.0.5",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-0.0.5.tgz"
+        },
+        "opt-merger": {
+          "version": "1.1.0",
+          "from": "opt-merger@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/opt-merger/-/opt-merger-1.1.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "minimist": {
+              "version": "1.1.1",
+              "from": "minimist@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "chalk": {
+      "version": "0.5.1",
+      "from": "chalk@>=0.5.1 <0.6.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "1.1.0",
+          "from": "ansi-styles@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.3",
+          "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "from": "has-ansi@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1",
+              "from": "ansi-regex@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "from": "strip-ansi@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "0.2.1",
+              "from": "ansi-regex@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "from": "supports-color@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+        }
+      }
+    },
+    "concat-stream": {
+      "version": "1.4.8",
+      "from": "concat-stream@>=1.4.7 <1.5.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "typedarray": {
+          "version": "0.0.6",
+          "from": "typedarray@>=0.0.5 <0.1.0",
+          "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@>=1.1.9 <1.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            }
+          }
+        }
+      }
+    },
+    "del": {
+      "version": "1.1.1",
+      "from": "del@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-1.1.1.tgz",
+      "dependencies": {
+        "each-async": {
+          "version": "1.1.1",
+          "from": "each-async@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "dependencies": {
+            "onetime": {
+              "version": "1.0.0",
+              "from": "onetime@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+            },
+            "set-immediate-shim": {
+              "version": "1.0.1",
+              "from": "set-immediate-shim@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+            }
+          }
+        },
+        "globby": {
+          "version": "1.2.0",
+          "from": "globby@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "dependencies": {
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.4.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "from": "is-path-cwd@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.0",
+          "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+          "dependencies": {
+            "is-path-inside": {
+              "version": "1.0.0",
+              "from": "is-path-inside@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+              "dependencies": {
+                "path-is-inside": {
+                  "version": "1.0.1",
+                  "from": "path-is-inside@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.3.4",
+          "from": "rimraf@>=2.2.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.4.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp": {
+      "version": "3.8.11",
+      "from": "gulp@>=3.8.10 <3.9.0",
+      "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.8.11.tgz",
+      "dependencies": {
+        "archy": {
+          "version": "1.0.0",
+          "from": "archy@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz"
+        },
+        "deprecated": {
+          "version": "0.0.1",
+          "from": "deprecated@>=0.0.1 <0.0.2",
+          "resolved": "https://registry.npmjs.org/deprecated/-/deprecated-0.0.1.tgz"
+        },
+        "interpret": {
+          "version": "0.3.10",
+          "from": "interpret@>=0.3.2 <0.4.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.3.10.tgz"
+        },
+        "liftoff": {
+          "version": "2.0.3",
+          "from": "liftoff@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.0.3.tgz",
+          "dependencies": {
+            "extend": {
+              "version": "2.0.1",
+              "from": "extend@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+            },
+            "findup-sync": {
+              "version": "0.2.1",
+              "from": "findup-sync@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@>=4.3.0 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "flagged-respawn": {
+              "version": "0.3.1",
+              "from": "flagged-respawn@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.1.1",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+        },
+        "orchestrator": {
+          "version": "0.3.7",
+          "from": "orchestrator@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/orchestrator/-/orchestrator-0.3.7.tgz",
+          "dependencies": {
+            "end-of-stream": {
+              "version": "0.1.5",
+              "from": "end-of-stream@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-0.1.5.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "sequencify": {
+              "version": "0.0.7",
+              "from": "sequencify@>=0.0.7 <0.1.0",
+              "resolved": "https://registry.npmjs.org/sequencify/-/sequencify-0.0.7.tgz"
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "from": "stream-consume@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+            }
+          }
+        },
+        "pretty-hrtime": {
+          "version": "0.2.2",
+          "from": "pretty-hrtime@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-0.2.2.tgz"
+        },
+        "semver": {
+          "version": "4.3.4",
+          "from": "semver@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+        },
+        "tildify": {
+          "version": "1.0.0",
+          "from": "tildify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            }
+          }
+        },
+        "v8flags": {
+          "version": "2.0.5",
+          "from": "v8flags@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.5.tgz",
+          "dependencies": {
+            "user-home": {
+              "version": "1.1.1",
+              "from": "user-home@>=1.1.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "0.3.13",
+          "from": "vinyl-fs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-0.3.13.tgz",
+          "dependencies": {
+            "defaults": {
+              "version": "1.0.2",
+              "from": "defaults@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.2.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.1.19",
+                  "from": "clone@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "3.1.18",
+              "from": "glob-stream@>=3.1.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-3.1.18.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "1.0.0",
+                  "from": "unique-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.6",
+              "from": "glob-watcher@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.6.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@>=3.1.21 <3.2.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.4",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-angular-filesort": {
+      "version": "1.0.4",
+      "from": "gulp-angular-filesort@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-angular-filesort/-/gulp-angular-filesort-1.0.4.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.1",
+          "from": "event-stream@>=3.1.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.1.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        },
+        "ng-dependencies": {
+          "version": "0.1.3",
+          "from": "ng-dependencies@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/ng-dependencies/-/ng-dependencies-0.1.3.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "sugar": {
+              "version": "1.4.1",
+              "from": "sugar@>=1.4.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sugar/-/sugar-1.4.1.tgz"
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "estraverse@>=1.5.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            }
+          }
+        },
+        "toposort": {
+          "version": "0.2.10",
+          "from": "toposort@>=0.2.10 <0.3.0",
+          "resolved": "https://registry.npmjs.org/toposort/-/toposort-0.2.10.tgz"
+        }
+      }
+    },
+    "gulp-angular-templatecache": {
+      "version": "1.5.0",
+      "from": "gulp-angular-templatecache@>=1.5.0 <1.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-angular-templatecache/-/gulp-angular-templatecache-1.5.0.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.1",
+          "from": "event-stream@>=3.1.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.1.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        },
+        "path": {
+          "version": "0.11.14",
+          "from": "path@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/path/-/path-0.11.14.tgz"
+        },
+        "js-string-escape": {
+          "version": "1.0.0",
+          "from": "js-string-escape@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.0.tgz"
+        },
+        "gulp-footer": {
+          "version": "1.0.5",
+          "from": "gulp-footer@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-footer/-/gulp-footer-1.0.5.tgz",
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "from": "lodash.assign@*",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.8",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz"
+                    },
+                    "lodash.restparam": {
+                      "version": "3.6.1",
+                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.0",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.0",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.3",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "gulp-header": {
+          "version": "1.2.2",
+          "from": "gulp-header@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.2.2.tgz",
+          "dependencies": {
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@*",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "through2": {
+              "version": "0.6.5",
+              "from": "through2@>=0.6.3 <0.7.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.0",
+                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-autoprefixer": {
+      "version": "2.1.0",
+      "from": "gulp-autoprefixer@>=2.1.0 <2.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-autoprefixer/-/gulp-autoprefixer-2.1.0.tgz",
+      "dependencies": {
+        "autoprefixer-core": {
+          "version": "5.1.11",
+          "from": "autoprefixer-core@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/autoprefixer-core/-/autoprefixer-core-5.1.11.tgz",
+          "dependencies": {
+            "browserslist": {
+              "version": "0.2.0",
+              "from": "browserslist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-0.2.0.tgz"
+            },
+            "num2fraction": {
+              "version": "1.1.0",
+              "from": "num2fraction@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
+            },
+            "caniuse-db": {
+              "version": "1.0.30000176",
+              "from": "caniuse-db@>=1.0.30000132 <2.0.0",
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000176.tgz"
+            },
+            "postcss": {
+              "version": "4.0.6",
+              "from": "postcss@>=4.0.6 <4.1.0",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-4.0.6.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.2.0",
+                  "from": "source-map@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "js-base64": {
+                  "version": "2.1.8",
+                  "from": "js-base64@>=2.1.7 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.1.8.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-coffee": {
+      "version": "2.3.1",
+      "from": "gulp-coffee@>=2.3.1 <2.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-coffee/-/gulp-coffee-2.3.1.tgz",
+      "dependencies": {
+        "coffee-script": {
+          "version": "1.9.2",
+          "from": "coffee-script@>=1.9.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.2.tgz"
+        },
+        "merge": {
+          "version": "1.2.0",
+          "from": "merge@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-coffeelint": {
+      "version": "0.4.0",
+      "from": "gulp-coffeelint@>=0.4.0 <0.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-coffeelint/-/gulp-coffeelint-0.4.0.tgz",
+      "dependencies": {
+        "args-js": {
+          "version": "0.10.6",
+          "from": "args-js@>=0.10.5 <0.11.0",
+          "resolved": "https://registry.npmjs.org/args-js/-/args-js-0.10.6.tgz"
+        },
+        "coffeelint": {
+          "version": "1.9.7",
+          "from": "coffeelint@>=1.4.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/coffeelint/-/coffeelint-1.9.7.tgz",
+          "dependencies": {
+            "coffee-script": {
+              "version": "1.9.2",
+              "from": "coffee-script@>=1.9.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.9.2.tgz"
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ignore": {
+              "version": "2.2.15",
+              "from": "ignore@>=2.2.15 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ignore/-/ignore-2.2.15.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "resolve": {
+              "version": "0.6.3",
+              "from": "resolve@>=0.6.3 <0.7.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.2",
+              "from": "strip-json-comments@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+            }
+          }
+        },
+        "coffeelint-stylish": {
+          "version": "0.1.2",
+          "from": "coffeelint-stylish@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/coffeelint-stylish/-/coffeelint-stylish-0.1.2.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.0.1",
+                  "from": "ansi-styles@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.3",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@>=1.0.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@>=4.0.1 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "supports-color@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                }
+              }
+            },
+            "text-table": {
+              "version": "0.2.0",
+              "from": "text-table@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-concat": {
+      "version": "2.5.2",
+      "from": "gulp-concat@>=2.5.2 <2.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-concat/-/gulp-concat-2.5.2.tgz",
+      "dependencies": {
+        "concat-with-sourcemaps": {
+          "version": "1.0.2",
+          "from": "concat-with-sourcemaps@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.0.2.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.2",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-consolidate": {
+      "version": "0.1.2",
+      "from": "gulp-consolidate@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-consolidate/-/gulp-consolidate-0.1.2.tgz",
+      "dependencies": {
+        "consolidate": {
+          "version": "0.10.0",
+          "from": "consolidate@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.10.0.tgz"
+        },
+        "map-stream": {
+          "version": "0.0.4",
+          "from": "map-stream@0.0.4",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.4.tgz"
+        }
+      }
+    },
+    "gulp-csso": {
+      "version": "1.0.0",
+      "from": "gulp-csso@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-csso/-/gulp-csso-1.0.0.tgz",
+      "dependencies": {
+        "csso": {
+          "version": "1.3.11",
+          "from": "csso@>=1.3.11 <1.4.0",
+          "resolved": "https://registry.npmjs.org/csso/-/csso-1.3.11.tgz"
+        }
+      }
+    },
+    "gulp-filter": {
+      "version": "2.0.2",
+      "from": "gulp-filter@>=2.0.2 <2.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-filter/-/gulp-filter-2.0.2.tgz",
+      "dependencies": {
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "plexer": {
+          "version": "0.0.3",
+          "from": "plexer@0.0.3",
+          "resolved": "https://registry.npmjs.org/plexer/-/plexer-0.0.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26-2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-flatten": {
+      "version": "0.0.4",
+      "from": "gulp-flatten@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-flatten/-/gulp-flatten-0.0.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-inject": {
+      "version": "1.1.1",
+      "from": "gulp-inject@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-inject/-/gulp-inject-1.1.1.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.1",
+          "from": "event-stream@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.1.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-jshint": {
+      "version": "1.9.4",
+      "from": "gulp-jshint@>=1.9.0 <1.10.0",
+      "resolved": "https://registry.npmjs.org/gulp-jshint/-/gulp-jshint-1.9.4.tgz",
+      "dependencies": {
+        "jshint": {
+          "version": "2.7.0",
+          "from": "jshint@>=2.5.6 <3.0.0",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.7.0.tgz",
+          "dependencies": {
+            "cli": {
+              "version": "0.6.6",
+              "from": "cli@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.1 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.8.2",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                }
+              }
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "strip-json-comments": {
+              "version": "1.0.2",
+              "from": "strip-json-comments@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+            },
+            "lodash": {
+              "version": "3.6.0",
+              "from": "lodash@>=3.6.0 <3.7.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rcloader": {
+          "version": "0.1.2",
+          "from": "rcloader@0.1.2",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
+          "dependencies": {
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "rcfinder@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <1.0.0-0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26-2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-less": {
+      "version": "3.0.3",
+      "from": "gulp-less@>=3.0.0 <3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-less/-/gulp-less-3.0.3.tgz",
+      "dependencies": {
+        "accord": {
+          "version": "0.15.2",
+          "from": "accord@>=0.15.2 <0.16.0",
+          "resolved": "https://registry.npmjs.org/accord/-/accord-0.15.2.tgz",
+          "dependencies": {
+            "convert-source-map": {
+              "version": "0.4.1",
+              "from": "convert-source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
+            },
+            "fobject": {
+              "version": "0.0.3",
+              "from": "fobject@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "semver@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "indx": {
+              "version": "0.2.3",
+              "from": "indx@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "when": {
+              "version": "3.7.3",
+              "from": "when@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
+            }
+          }
+        },
+        "less": {
+          "version": "2.5.1",
+          "from": "less@>=2.4.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/less/-/less-2.5.1.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.2",
+              "from": "errno@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.2.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            },
+            "image-size": {
+              "version": "0.3.5",
+              "from": "image-size@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.3.5.tgz"
+            },
+            "mime": {
+              "version": "1.3.4",
+              "from": "mime@>=1.2.11 <2.0.0",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "6.1.0",
+              "from": "promise@>=6.0.1 <7.0.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-6.1.0.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "1.0.0",
+                  "from": "asap@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/asap/-/asap-1.0.0.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.55.0",
+              "from": "request@>=2.51.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.12",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.10.0 <1.11.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.4.2",
+                  "from": "qs@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.1.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.13.0",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.7.2",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.7.0",
+                  "from": "har-validator@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.25",
+                      "from": "bluebird@>=2.9.25 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.0",
+                      "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.4.2",
+              "from": "source-map@>=0.4.2 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-load-plugins": {
+      "version": "0.8.1",
+      "from": "gulp-load-plugins@>=0.8.0 <0.9.0",
+      "resolved": "https://registry.npmjs.org/gulp-load-plugins/-/gulp-load-plugins-0.8.1.tgz",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@>=4.3.0 <4.4.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.0.0",
+          "from": "multimatch@2.0.0",
+          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-minify-html": {
+      "version": "0.1.8",
+      "from": "gulp-minify-html@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-minify-html/-/gulp-minify-html-0.1.8.tgz",
+      "dependencies": {
+        "gulp-util": {
+          "version": "2.2.20",
+          "from": "gulp-util@>=2.2.14 <2.3.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "dependencies": {
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "2.0.0",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "lodash.values@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimize": {
+          "version": "1.4.1",
+          "from": "minimize@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimize/-/minimize-1.4.1.tgz",
+          "dependencies": {
+            "argh": {
+              "version": "0.1.3",
+              "from": "argh@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/argh/-/argh-0.1.3.tgz"
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "cli-color": {
+              "version": "0.3.3",
+              "from": "cli-color@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "0.1.1",
+                  "from": "d@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.7",
+                  "from": "es5-ext@>=0.10.6 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.3",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "2.0.1",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                    }
+                  }
+                },
+                "memoizee": {
+                  "version": "0.3.8",
+                  "from": "memoizee@>=0.3.8 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+                  "dependencies": {
+                    "es6-weak-map": {
+                      "version": "0.1.4",
+                      "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                      "dependencies": {
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.3 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                        },
+                        "es6-symbol": {
+                          "version": "2.0.1",
+                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                        }
+                      }
+                    },
+                    "event-emitter": {
+                      "version": "0.3.3",
+                      "from": "event-emitter@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                    },
+                    "lru-queue": {
+                      "version": "0.1.0",
+                      "from": "lru-queue@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                    },
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                },
+                "timers-ext": {
+                  "version": "0.1.0",
+                  "from": "timers-ext@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+                  "dependencies": {
+                    "next-tick": {
+                      "version": "0.2.2",
+                      "from": "next-tick@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "diagnostics": {
+              "version": "0.0.4",
+              "from": "diagnostics@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-0.0.4.tgz",
+              "dependencies": {
+                "color": {
+                  "version": "0.7.3",
+                  "from": "color@>=0.7.0 <0.8.0",
+                  "resolved": "https://registry.npmjs.org/color/-/color-0.7.3.tgz",
+                  "dependencies": {
+                    "color-convert": {
+                      "version": "0.5.2",
+                      "from": "color-convert@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.2.tgz"
+                    },
+                    "color-string": {
+                      "version": "0.2.4",
+                      "from": "color-string@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/color-string/-/color-string-0.2.4.tgz",
+                      "dependencies": {
+                        "color-name": {
+                          "version": "1.0.0",
+                          "from": "color-name@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "colornames": {
+                  "version": "0.0.2",
+                  "from": "colornames@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/colornames/-/colornames-0.0.2.tgz"
+                },
+                "env-variable": {
+                  "version": "0.0.3",
+                  "from": "env-variable@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.3.tgz"
+                },
+                "kuler": {
+                  "version": "0.0.0",
+                  "from": "kuler@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/kuler/-/kuler-0.0.0.tgz"
+                },
+                "text-hex": {
+                  "version": "0.0.0",
+                  "from": "text-hex@>=0.0.0 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-0.0.0.tgz"
+                }
+              }
+            },
+            "emits": {
+              "version": "1.0.2",
+              "from": "emits@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/emits/-/emits-1.0.2.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.8.2",
+              "from": "htmlparser2@>=3.8.0 <3.9.0",
+              "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@>=0.0.0 <1.0.0",
+                      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@>=1.1.1 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.5.1",
+          "from": "through2@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "3.0.0",
+              "from": "xtend@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-ng-annotate": {
+      "version": "0.5.3",
+      "from": "gulp-ng-annotate@>=0.5.2 <0.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-ng-annotate/-/gulp-ng-annotate-0.5.3.tgz",
+      "dependencies": {
+        "bufferstreams": {
+          "version": "0.0.2",
+          "from": "bufferstreams@>=0.0.2 <0.1.0",
+          "resolved": "https://registry.npmjs.org/bufferstreams/-/bufferstreams-0.0.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.26-2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "2.2.20",
+          "from": "gulp-util@>=2.2.14 <2.3.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "dependencies": {
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "2.0.0",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "lodash.values@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "merge": {
+          "version": "1.2.0",
+          "from": "merge@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+        },
+        "ng-annotate": {
+          "version": "0.15.4",
+          "from": "ng-annotate@>=0.15.1 <0.16.0",
+          "resolved": "https://registry.npmjs.org/ng-annotate/-/ng-annotate-0.15.4.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "0.11.0",
+              "from": "acorn@>=0.11.0 <0.12.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.11.0.tgz"
+            },
+            "alter": {
+              "version": "0.2.0",
+              "from": "alter@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz"
+            },
+            "convert-source-map": {
+              "version": "0.4.1",
+              "from": "convert-source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "ordered-ast-traverse": {
+              "version": "1.1.1",
+              "from": "ordered-ast-traverse@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/ordered-ast-traverse/-/ordered-ast-traverse-1.1.1.tgz",
+              "dependencies": {
+                "ordered-esprima-props": {
+                  "version": "1.1.0",
+                  "from": "ordered-esprima-props@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/ordered-esprima-props/-/ordered-esprima-props-1.1.0.tgz"
+                }
+              }
+            },
+            "simple-fmt": {
+              "version": "0.1.0",
+              "from": "simple-fmt@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
+            },
+            "simple-is": {
+              "version": "0.2.0",
+              "from": "simple-is@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.43 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "stable": {
+              "version": "0.1.5",
+              "from": "stable@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
+            },
+            "stringmap": {
+              "version": "0.2.2",
+              "from": "stringmap@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
+            },
+            "stringset": {
+              "version": "0.2.1",
+              "from": "stringset@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
+            },
+            "tryor": {
+              "version": "0.1.2",
+              "from": "tryor@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-protractor": {
+      "version": "0.0.12",
+      "from": "gulp-protractor@>=0.0.12 <0.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-protractor/-/gulp-protractor-0.0.12.tgz",
+      "dependencies": {
+        "event-stream": {
+          "version": "3.3.1",
+          "from": "event-stream@>=3.1.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.1.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.1 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            },
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            },
+            "from": {
+              "version": "0.1.3",
+              "from": "from@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/from/-/from-0.1.3.tgz"
+            },
+            "map-stream": {
+              "version": "0.1.0",
+              "from": "map-stream@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+            },
+            "pause-stream": {
+              "version": "0.0.11",
+              "from": "pause-stream@0.0.11",
+              "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz"
+            },
+            "stream-combiner": {
+              "version": "0.0.4",
+              "from": "stream-combiner@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
+            }
+          }
+        },
+        "async": {
+          "version": "0.7.0",
+          "from": "async@>=0.7.0 <0.8.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.7.0.tgz"
+        },
+        "dargs": {
+          "version": "3.0.1",
+          "from": "dargs@>=0.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-3.0.1.tgz"
+        },
+        "protractor": {
+          "version": "1.8.0",
+          "from": "protractor@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/protractor/-/protractor-1.8.0.tgz",
+          "dependencies": {
+            "request": {
+              "version": "2.36.0",
+              "from": "request@>=2.36.0 <2.37.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.36.0.tgz",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.6",
+                  "from": "qs@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@>=1.2.9 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.1.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.0.0",
+                  "from": "hawk@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.0.0.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                }
+              }
+            },
+            "selenium-webdriver": {
+              "version": "2.44.0",
+              "from": "selenium-webdriver@2.44.0",
+              "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-2.44.0.tgz",
+              "dependencies": {
+                "tmp": {
+                  "version": "0.0.24",
+                  "from": "tmp@0.0.24",
+                  "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.24.tgz"
+                },
+                "xml2js": {
+                  "version": "0.4.4",
+                  "from": "xml2js@0.4.4",
+                  "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.4.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "0.6.1",
+                      "from": "sax@>=0.6.0 <0.7.0",
+                      "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz"
+                    },
+                    "xmlbuilder": {
+                      "version": "2.6.2",
+                      "from": "xmlbuilder@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "3.5.0",
+                          "from": "lodash@>=3.5.0 <3.6.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "minijasminenode": {
+              "version": "1.1.1",
+              "from": "minijasminenode@1.1.1",
+              "resolved": "https://registry.npmjs.org/minijasminenode/-/minijasminenode-1.1.1.tgz"
+            },
+            "jasminewd": {
+              "version": "1.1.0",
+              "from": "jasminewd@1.1.0",
+              "resolved": "https://registry.npmjs.org/jasminewd/-/jasminewd-1.1.0.tgz"
+            },
+            "jasminewd2": {
+              "version": "0.0.2",
+              "from": "jasminewd2@0.0.2",
+              "resolved": "https://registry.npmjs.org/jasminewd2/-/jasminewd2-0.0.2.tgz"
+            },
+            "jasmine": {
+              "version": "2.1.1",
+              "from": "jasmine@2.1.1",
+              "resolved": "https://registry.npmjs.org/jasmine/-/jasmine-2.1.1.tgz",
+              "dependencies": {
+                "jasmine-core": {
+                  "version": "2.1.3",
+                  "from": "jasmine-core@>=2.1.0 <2.2.0",
+                  "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.1.3.tgz"
+                }
+              }
+            },
+            "saucelabs": {
+              "version": "0.1.1",
+              "from": "saucelabs@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "q": {
+              "version": "1.0.0",
+              "from": "q@1.0.0",
+              "resolved": "https://registry.npmjs.org/q/-/q-1.0.0.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "from": "source-map-support@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "html-entities": {
+              "version": "1.1.2",
+              "from": "html-entities@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.1.2.tgz"
+            },
+            "accessibility-developer-tools": {
+              "version": "2.6.0",
+              "from": "accessibility-developer-tools@>=2.6.0 <2.7.0",
+              "resolved": "https://registry.npmjs.org/accessibility-developer-tools/-/accessibility-developer-tools-2.6.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-rename": {
+      "version": "1.2.2",
+      "from": "gulp-rename@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+    },
+    "gulp-replace": {
+      "version": "0.5.3",
+      "from": "gulp-replace@>=0.5.0 <0.6.0",
+      "resolved": "https://registry.npmjs.org/gulp-replace/-/gulp-replace-0.5.3.tgz",
+      "dependencies": {
+        "istextorbinary": {
+          "version": "1.0.2",
+          "from": "istextorbinary@1.0.2",
+          "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-1.0.2.tgz",
+          "dependencies": {
+            "textextensions": {
+              "version": "1.0.1",
+              "from": "textextensions@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.1.tgz"
+            },
+            "binaryextensions": {
+              "version": "1.0.0",
+              "from": "binaryextensions@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-1.0.0.tgz"
+            }
+          }
+        },
+        "replacestream": {
+          "version": "2.0.0",
+          "from": "replacestream@2.0.0",
+          "resolved": "https://registry.npmjs.org/replacestream/-/replacestream-2.0.0.tgz",
+          "dependencies": {
+            "through": {
+              "version": "2.3.7",
+              "from": "through@>=2.3.4 <2.4.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.3",
+          "from": "through2@0.6.3",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-rev": {
+      "version": "3.0.1",
+      "from": "gulp-rev@>=3.0.1 <3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-3.0.1.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-file": {
+          "version": "1.1.1",
+          "from": "vinyl-file@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-1.1.1.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.3 <0.5.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-rev-replace": {
+      "version": "0.3.4",
+      "from": "gulp-rev-replace@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev-replace/-/gulp-rev-replace-0.3.4.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.4.2",
+          "from": "through2@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "2.1.2",
+              "from": "xtend@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+              "dependencies": {
+                "object-keys": {
+                  "version": "0.4.0",
+                  "from": "object-keys@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gulp-util": {
+          "version": "2.2.20",
+          "from": "gulp-util@>=2.2.14 <2.3.0",
+          "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+          "dependencies": {
+            "dateformat": {
+              "version": "1.0.11",
+              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@*",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                },
+                "meow": {
+                  "version": "3.1.0",
+                  "from": "meow@*",
+                  "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "dependencies": {
+                    "camelcase-keys": {
+                      "version": "1.0.0",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                        },
+                        "map-obj": {
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "indent-string": {
+                      "version": "1.2.1",
+                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                      "dependencies": {
+                        "repeating": {
+                          "version": "1.1.2",
+                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                          "dependencies": {
+                            "is-finite": {
+                              "version": "1.0.1",
+                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                              "dependencies": {
+                                "number-is-nan": {
+                                  "version": "1.0.0",
+                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "minimist": {
+                      "version": "1.1.1",
+                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                    },
+                    "object-assign": {
+                      "version": "2.0.0",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._reinterpolate": {
+              "version": "2.4.1",
+              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+            },
+            "lodash.template": {
+              "version": "2.4.1",
+              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+              "dependencies": {
+                "lodash.defaults": {
+                  "version": "2.4.1",
+                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._objecttypes": {
+                      "version": "2.4.1",
+                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                    }
+                  }
+                },
+                "lodash.escape": {
+                  "version": "2.4.1",
+                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._escapehtmlchar": {
+                      "version": "2.4.1",
+                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._reunescapedhtml": {
+                      "version": "2.4.1",
+                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._htmlescapes": {
+                          "version": "2.4.1",
+                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._escapestringchar": {
+                  "version": "2.4.1",
+                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "2.4.1",
+                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash._isnative": {
+                      "version": "2.4.1",
+                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                    },
+                    "lodash.isobject": {
+                      "version": "2.4.1",
+                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash._shimkeys": {
+                      "version": "2.4.1",
+                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash.templatesettings": {
+                  "version": "2.4.1",
+                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                },
+                "lodash.values": {
+                  "version": "2.4.1",
+                  "from": "lodash.values@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                }
+              }
+            },
+            "minimist": {
+              "version": "0.2.0",
+              "from": "minimist@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+            },
+            "multipipe": {
+              "version": "0.1.2",
+              "from": "multipipe@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@0.0.2",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.2.3",
+              "from": "vinyl@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+              "dependencies": {
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-ruby-sass": {
+      "version": "0.7.1",
+      "from": "gulp-ruby-sass@>=0.7.1 <0.8.0",
+      "resolved": "https://registry.npmjs.org/gulp-ruby-sass/-/gulp-ruby-sass-0.7.1.tgz",
+      "dependencies": {
+        "dargs": {
+          "version": "0.1.0",
+          "from": "dargs@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/dargs/-/dargs-0.1.0.tgz"
+        },
+        "each-async": {
+          "version": "0.1.3",
+          "from": "each-async@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-0.1.3.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.0.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gulp-intermediate": {
+          "version": "3.0.1",
+          "from": "gulp-intermediate@3.0.1",
+          "resolved": "https://registry.npmjs.org/gulp-intermediate/-/gulp-intermediate-3.0.1.tgz",
+          "dependencies": {
+            "gulp-util": {
+              "version": "2.2.20",
+              "from": "gulp-util@>=2.2.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
+              "dependencies": {
+                "dateformat": {
+                  "version": "1.0.11",
+                  "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+                  "dependencies": {
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@*",
+                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                    },
+                    "meow": {
+                      "version": "3.1.0",
+                      "from": "meow@*",
+                      "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                      "dependencies": {
+                        "camelcase-keys": {
+                          "version": "1.0.0",
+                          "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                          "dependencies": {
+                            "camelcase": {
+                              "version": "1.1.0",
+                              "from": "camelcase@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                            },
+                            "map-obj": {
+                              "version": "1.0.1",
+                              "from": "map-obj@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "indent-string": {
+                          "version": "1.2.1",
+                          "from": "indent-string@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                          "dependencies": {
+                            "repeating": {
+                              "version": "1.1.2",
+                              "from": "repeating@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                              "dependencies": {
+                                "is-finite": {
+                                  "version": "1.0.1",
+                                  "from": "is-finite@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                                  "dependencies": {
+                                    "number-is-nan": {
+                                      "version": "1.0.0",
+                                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "minimist": {
+                          "version": "1.1.1",
+                          "from": "minimist@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                        },
+                        "object-assign": {
+                          "version": "2.0.0",
+                          "from": "object-assign@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash._reinterpolate": {
+                  "version": "2.4.1",
+                  "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
+                },
+                "lodash.template": {
+                  "version": "2.4.1",
+                  "from": "lodash.template@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
+                  "dependencies": {
+                    "lodash.defaults": {
+                      "version": "2.4.1",
+                      "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._objecttypes": {
+                          "version": "2.4.1",
+                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                        }
+                      }
+                    },
+                    "lodash.escape": {
+                      "version": "2.4.1",
+                      "from": "lodash.escape@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._escapehtmlchar": {
+                          "version": "2.4.1",
+                          "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._reunescapedhtml": {
+                          "version": "2.4.1",
+                          "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._htmlescapes": {
+                              "version": "2.4.1",
+                              "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash._escapestringchar": {
+                      "version": "2.4.1",
+                      "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
+                    },
+                    "lodash.keys": {
+                      "version": "2.4.1",
+                      "from": "lodash.keys@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
+                      "dependencies": {
+                        "lodash._isnative": {
+                          "version": "2.4.1",
+                          "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
+                        },
+                        "lodash.isobject": {
+                          "version": "2.4.1",
+                          "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        },
+                        "lodash._shimkeys": {
+                          "version": "2.4.1",
+                          "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                          "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
+                          "dependencies": {
+                            "lodash._objecttypes": {
+                              "version": "2.4.1",
+                              "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                              "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash.templatesettings": {
+                      "version": "2.4.1",
+                      "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
+                    },
+                    "lodash.values": {
+                      "version": "2.4.1",
+                      "from": "lodash.values@>=2.4.1 <2.5.0",
+                      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "0.2.0",
+                  "from": "minimist@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
+                },
+                "multipipe": {
+                  "version": "0.1.2",
+                  "from": "multipipe@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+                  "dependencies": {
+                    "duplexer2": {
+                      "version": "0.0.2",
+                      "from": "duplexer2@0.0.2",
+                      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.9 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "vinyl": {
+                  "version": "0.2.3",
+                  "from": "vinyl@>=0.2.1 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
+                  "dependencies": {
+                    "clone-stats": {
+                      "version": "0.0.1",
+                      "from": "clone-stats@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.3.4",
+              "from": "rimraf@>=2.2.8 <3.0.0",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "through2": {
+              "version": "0.5.1",
+              "from": "through2@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "3.0.0",
+                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
+                }
+              }
+            },
+            "uuid": {
+              "version": "1.4.2",
+              "from": "uuid@>=1.4.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-1.4.2.tgz"
+            }
+          }
+        },
+        "slash": {
+          "version": "0.1.3",
+          "from": "slash@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-0.1.3.tgz"
+        },
+        "win-spawn": {
+          "version": "2.0.0",
+          "from": "win-spawn@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/win-spawn/-/win-spawn-2.0.0.tgz"
+        }
+      }
+    },
+    "gulp-sass": {
+      "version": "1.3.3",
+      "from": "gulp-sass@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-1.3.3.tgz",
+      "dependencies": {
+        "clone": {
+          "version": "0.1.19",
+          "from": "clone@>=0.1.18 <0.2.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+        },
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "map-stream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+        },
+        "node-sass": {
+          "version": "2.1.1",
+          "from": "node-sass@>=2.0.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-2.1.1.tgz",
+          "dependencies": {
+            "cross-spawn": {
+              "version": "0.2.9",
+              "from": "cross-spawn@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-0.2.9.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.5.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                }
+              }
+            },
+            "gaze": {
+              "version": "0.5.1",
+              "from": "gaze@>=0.5.1 <0.6.0",
+              "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+              "dependencies": {
+                "globule": {
+                  "version": "0.1.0",
+                  "from": "globule@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                  "dependencies": {
+                    "lodash": {
+                      "version": "1.0.2",
+                      "from": "lodash@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                    },
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@>=3.1.21 <3.2.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.3",
+                          "from": "graceful-fs@>=1.2.0 <1.3.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.0",
+                          "from": "inherits@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "mocha": {
+              "version": "2.2.5",
+              "from": "mocha@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.2.5.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.3.0",
+                  "from": "commander@2.3.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+                },
+                "debug": {
+                  "version": "2.0.0",
+                  "from": "debug@2.0.0",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.4.0",
+                  "from": "diff@1.4.0",
+                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.2",
+                  "from": "escape-string-regexp@1.0.2",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                },
+                "glob": {
+                  "version": "3.2.3",
+                  "from": "glob@3.2.3",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.11 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "growl": {
+                  "version": "1.8.1",
+                  "from": "growl@1.8.1",
+                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.8.1.tgz"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                  "dependencies": {
+                    "commander": {
+                      "version": "0.6.1",
+                      "from": "commander@0.6.1",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.0",
+                  "from": "mkdirp@0.5.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.2.1",
+                  "from": "supports-color@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.1.tgz"
+                }
+              }
+            },
+            "nan": {
+              "version": "1.8.4",
+              "from": "nan@>=1.6.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+            },
+            "npmconf": {
+              "version": "2.1.2",
+              "from": "npmconf@>=2.1.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.2.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.8",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.6",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.1",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "replace-ext": {
+              "version": "0.0.1",
+              "from": "replace-ext@0.0.1",
+              "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+            },
+            "request": {
+              "version": "2.55.0",
+              "from": "request@>=2.53.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.12",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.10.0 <1.11.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "qs": {
+                  "version": "2.4.2",
+                  "from": "qs@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.1.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.13.0",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.13.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.7.2",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.7.0",
+                  "from": "har-validator@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.25",
+                      "from": "bluebird@>=2.9.25 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.25.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.0",
+                      "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "sass-graph": {
+              "version": "1.3.0",
+              "from": "sass-graph@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-1.3.0.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "2.8.1",
+                  "from": "commander@>=2.6.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                  "dependencies": {
+                    "graceful-readlink": {
+                      "version": "1.0.1",
+                      "from": "graceful-readlink@>=1.0.0",
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.4 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "2.0.8",
+                      "from": "minimatch@>=2.0.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.0",
+                          "from": "brace-expansion@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "0.2.0",
+                              "from": "balanced-match@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.4",
+              "from": "semver@>=4.2.2 <5.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+            },
+            "pangyp": {
+              "version": "2.2.0",
+              "from": "pangyp@>=2.1.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/pangyp/-/pangyp-2.2.0.tgz",
+              "dependencies": {
+                "fstream": {
+                  "version": "1.0.6",
+                  "from": "fstream@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.6.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "glob": {
+                  "version": "4.3.5",
+                  "from": "glob@>=4.3.5 <4.4.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.5 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.6",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                    }
+                  }
+                },
+                "npmlog": {
+                  "version": "1.0.0",
+                  "from": "npmlog@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.0.0.tgz",
+                  "dependencies": {
+                    "ansi": {
+                      "version": "0.3.0",
+                      "from": "ansi@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.0.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.0.4",
+                      "from": "are-we-there-yet@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.4.tgz",
+                      "dependencies": {
+                        "delegates": {
+                          "version": "0.1.0",
+                          "from": "delegates@>=0.1.0 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/delegates/-/delegates-0.1.0.tgz"
+                        },
+                        "readable-stream": {
+                          "version": "1.1.13",
+                          "from": "readable-stream@>=1.1.13 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "gauge": {
+                      "version": "1.0.2",
+                      "from": "gauge@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.0.2.tgz",
+                      "dependencies": {
+                        "has-unicode": {
+                          "version": "1.0.0",
+                          "from": "has-unicode@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.1",
+                  "from": "osenv@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                },
+                "request": {
+                  "version": "2.51.0",
+                  "from": "request@>=2.51.0 <2.52.0",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.4",
+                      "from": "bl@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.26 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.8.0",
+                      "from": "caseless@>=0.8.0 <0.9.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                    },
+                    "form-data": {
+                      "version": "0.2.0",
+                      "from": "form-data@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                      "dependencies": {
+                        "async": {
+                          "version": "0.9.2",
+                          "from": "async@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.0.12",
+                          "from": "mime-types@>=2.0.3 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.10.0",
+                              "from": "mime-db@>=1.10.0 <1.11.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.3",
+                      "from": "node-uuid@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                    },
+                    "qs": {
+                      "version": "2.3.3",
+                      "from": "qs@>=2.3.1 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.0",
+                      "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "1.1.0",
+                      "from": "tough-cookie@>=0.12.0",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@>=0.1.5 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11",
+                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3",
+                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.5.0",
+                      "from": "oauth-sign@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@>=0.9.0 <0.10.0",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.4",
+                      "from": "stringstream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.5 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "rimraf": {
+                  "version": "2.2.8",
+                  "from": "rimraf@>=2.2.8 <2.3.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+                },
+                "semver": {
+                  "version": "4.2.2",
+                  "from": "semver@>=4.2.0 <4.3.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.2.tgz"
+                },
+                "tar": {
+                  "version": "1.0.3",
+                  "from": "tar@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/tar/-/tar-1.0.3.tgz",
+                  "dependencies": {
+                    "block-stream": {
+                      "version": "0.0.8",
+                      "from": "block-stream@*",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.0.9",
+                  "from": "which@>=1.0.8 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                }
+              }
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-size": {
+      "version": "1.2.1",
+      "from": "gulp-size@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-size/-/gulp-size-1.2.1.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "gzip-size": {
+          "version": "1.0.0",
+          "from": "gzip-size@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-1.0.0.tgz",
+          "dependencies": {
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.6",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+                }
+              }
+            }
+          }
+        },
+        "pretty-bytes": {
+          "version": "1.0.4",
+          "from": "pretty-bytes@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.4.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@>=3.1.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.1.1",
+                  "from": "minimist@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+                },
+                "object-assign": {
+                  "version": "2.0.0",
+                  "from": "object-assign@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-sourcemaps": {
+      "version": "1.3.0",
+      "from": "gulp-sourcemaps@>=1.3.0 <1.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.3.0.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.0 <0.5.0-0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "from": "clone@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        },
+        "convert-source-map": {
+          "version": "0.4.1",
+          "from": "convert-source-map@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
+        }
+      }
+    },
+    "gulp-stylus": {
+      "version": "2.0.2",
+      "from": "gulp-stylus@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-stylus/-/gulp-stylus-2.0.2.tgz",
+      "dependencies": {
+        "accord": {
+          "version": "0.15.2",
+          "from": "accord@>=0.15.2 <0.16.0",
+          "resolved": "https://registry.npmjs.org/accord/-/accord-0.15.2.tgz",
+          "dependencies": {
+            "convert-source-map": {
+              "version": "0.4.1",
+              "from": "convert-source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
+            },
+            "fobject": {
+              "version": "0.0.3",
+              "from": "fobject@>=0.0.0 <1.0.0",
+              "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "semver@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "indx": {
+              "version": "0.2.3",
+              "from": "indx@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/indx/-/indx-0.2.3.tgz"
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "when": {
+              "version": "3.7.3",
+              "from": "when@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
+            }
+          }
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "replace-ext@0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+        },
+        "stylus": {
+          "version": "0.51.1",
+          "from": "stylus@*",
+          "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.51.1.tgz",
+          "dependencies": {
+            "css-parse": {
+              "version": "1.7.0",
+              "from": "css-parse@>=1.7.0 <1.8.0",
+              "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz"
+            },
+            "mkdirp": {
+              "version": "0.3.5",
+              "from": "mkdirp@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@*",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                }
+              }
+            },
+            "sax": {
+              "version": "0.5.8",
+              "from": "sax@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz"
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.0 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-tslint": {
+      "version": "1.4.4",
+      "from": "gulp-tslint@>=1.4.1 <1.5.0",
+      "resolved": "https://registry.npmjs.org/gulp-tslint/-/gulp-tslint-1.4.4.tgz",
+      "dependencies": {
+        "map-stream": {
+          "version": "0.1.0",
+          "from": "map-stream@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz"
+        },
+        "rcloader": {
+          "version": "0.1.4",
+          "from": "rcloader@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.4.tgz",
+          "dependencies": {
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "rcfinder@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.7",
+          "from": "through@>=2.3.6 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+        },
+        "tslint": {
+          "version": "2.1.1",
+          "from": "tslint@>=2.1.1 <2.2.0",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-2.1.1.tgz",
+          "dependencies": {
+            "findup-sync": {
+              "version": "0.1.3",
+              "from": "findup-sync@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.3.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@>=3.2.9 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@>=2.4.1 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@>=2.3.3 <2.4.0",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-typescript": {
+      "version": "2.6.0",
+      "from": "gulp-typescript@>=2.6.0 <2.7.0",
+      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-2.6.0.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.2",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "typescript": {
+          "version": "1.4.1",
+          "from": "typescript@1.4.1",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.4.1.tgz"
+        }
+      }
+    },
+    "gulp-uglify": {
+      "version": "1.1.0",
+      "from": "gulp-uglify@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-uglify/-/gulp-uglify-1.1.0.tgz",
+      "dependencies": {
+        "deepmerge": {
+          "version": "0.2.10",
+          "from": "deepmerge@>=0.2.7 <0.3.0-0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-0.2.10.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.4.16",
+          "from": "uglify-js@2.4.16",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.16.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.3.7",
+              "from": "optimist@>=0.3.5 <0.4.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            }
+          }
+        },
+        "vinyl-sourcemaps-apply": {
+          "version": "0.1.4",
+          "from": "vinyl-sourcemaps-apply@>=0.1.1 <0.2.0-0",
+          "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.39 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-useref": {
+      "version": "1.1.2",
+      "from": "gulp-useref@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/gulp-useref/-/gulp-useref-1.1.2.tgz",
+      "dependencies": {
+        "brace-expansion": {
+          "version": "1.1.0",
+          "from": "brace-expansion@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+          "dependencies": {
+            "balanced-match": {
+              "version": "0.2.0",
+              "from": "balanced-match@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "from": "concat-map@0.0.1",
+              "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+            }
+          }
+        },
+        "gulp-if": {
+          "version": "1.2.5",
+          "from": "gulp-if@>=1.2.5 <2.0.0",
+          "resolved": "https://registry.npmjs.org/gulp-if/-/gulp-if-1.2.5.tgz",
+          "dependencies": {
+            "gulp-match": {
+              "version": "0.2.1",
+              "from": "gulp-match@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/gulp-match/-/gulp-match-0.2.1.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "1.0.0",
+                  "from": "minimatch@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ternary-stream": {
+              "version": "1.2.3",
+              "from": "ternary-stream@>=1.2.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ternary-stream/-/ternary-stream-1.2.3.tgz",
+              "dependencies": {
+                "duplexer2": {
+                  "version": "0.0.2",
+                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.1.13",
+                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fork-stream": {
+                  "version": "0.0.4",
+                  "from": "fork-stream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/fork-stream/-/fork-stream-0.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "is-relative-url": {
+          "version": "1.0.0",
+          "from": "is-relative-url@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/is-relative-url/-/is-relative-url-1.0.0.tgz",
+          "dependencies": {
+            "is-absolute-url": {
+              "version": "1.0.0",
+              "from": "is-absolute-url@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-1.0.0.tgz"
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.9.1",
+          "from": "lodash@>=3.3.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.9.1.tgz"
+        },
+        "node-useref": {
+          "version": "0.3.12",
+          "from": "node-useref@>=0.3.1 <0.4.0",
+          "resolved": "https://registry.npmjs.org/node-useref/-/node-useref-0.3.12.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl-fs": {
+          "version": "1.0.0",
+          "from": "vinyl-fs@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
+          "dependencies": {
+            "duplexify": {
+              "version": "3.4.0",
+              "from": "duplexify@>=3.2.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.0.tgz",
+              "dependencies": {
+                "end-of-stream": {
+                  "version": "1.0.0",
+                  "from": "end-of-stream@1.0.0",
+                  "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
+                  "dependencies": {
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "glob-stream": {
+              "version": "4.1.1",
+              "from": "glob-stream@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-4.1.1.tgz",
+              "dependencies": {
+                "glob": {
+                  "version": "4.5.3",
+                  "from": "glob@>=4.3.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                  "dependencies": {
+                    "inflight": {
+                      "version": "1.0.4",
+                      "from": "inflight@>=1.0.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.3.2",
+                      "from": "once@>=1.3.0 <1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz"
+                },
+                "ordered-read-streams": {
+                  "version": "0.1.0",
+                  "from": "ordered-read-streams@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.1.0.tgz"
+                },
+                "glob2base": {
+                  "version": "0.0.12",
+                  "from": "glob2base@>=0.0.12 <0.0.13",
+                  "resolved": "https://registry.npmjs.org/glob2base/-/glob2base-0.0.12.tgz",
+                  "dependencies": {
+                    "find-index": {
+                      "version": "0.1.1",
+                      "from": "find-index@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/find-index/-/find-index-0.1.1.tgz"
+                    }
+                  }
+                },
+                "unique-stream": {
+                  "version": "2.0.2",
+                  "from": "unique-stream@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/unique-stream/-/unique-stream-2.0.2.tgz",
+                  "dependencies": {
+                    "es6-set": {
+                      "version": "0.1.1",
+                      "from": "es6-set@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.1.tgz",
+                      "dependencies": {
+                        "d": {
+                          "version": "0.1.1",
+                          "from": "d@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+                        },
+                        "es5-ext": {
+                          "version": "0.10.7",
+                          "from": "es5-ext@>=0.10.4 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-iterator": {
+                          "version": "0.1.3",
+                          "from": "es6-iterator@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                          "dependencies": {
+                            "es6-symbol": {
+                              "version": "2.0.1",
+                              "from": "es6-symbol@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                            }
+                          }
+                        },
+                        "es6-symbol": {
+                          "version": "0.1.1",
+                          "from": "es6-symbol@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                        },
+                        "event-emitter": {
+                          "version": "0.3.3",
+                          "from": "event-emitter@>=0.3.1 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+                        }
+                      }
+                    },
+                    "through2-filter": {
+                      "version": "1.4.1",
+                      "from": "through2-filter@>=1.4.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/through2-filter/-/through2-filter-1.4.1.tgz",
+                      "dependencies": {
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <4.1.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "glob-watcher": {
+              "version": "0.0.8",
+              "from": "glob-watcher@>=0.0.8 <0.0.9",
+              "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-0.0.8.tgz",
+              "dependencies": {
+                "gaze": {
+                  "version": "0.5.1",
+                  "from": "gaze@>=0.5.1 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.5.1.tgz",
+                  "dependencies": {
+                    "globule": {
+                      "version": "0.1.0",
+                      "from": "globule@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/globule/-/globule-0.1.0.tgz",
+                      "dependencies": {
+                        "lodash": {
+                          "version": "1.0.2",
+                          "from": "lodash@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.0.2.tgz"
+                        },
+                        "glob": {
+                          "version": "3.1.21",
+                          "from": "glob@>=3.1.21 <3.2.0",
+                          "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "1.2.3",
+                              "from": "graceful-fs@>=1.2.0 <1.3.0",
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
+                            },
+                            "inherits": {
+                              "version": "1.0.0",
+                              "from": "inherits@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@>=0.2.11 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.4",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "2.0.0",
+              "from": "object-assign@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+            },
+            "strip-bom": {
+              "version": "1.0.0",
+              "from": "strip-bom@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-1.0.0.tgz",
+              "dependencies": {
+                "first-chunk-stream": {
+                  "version": "1.0.0",
+                  "from": "first-chunk-stream@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz"
+                },
+                "is-utf8": {
+                  "version": "0.2.0",
+                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.0.tgz"
+                }
+              }
+            },
+            "vinyl": {
+              "version": "0.4.6",
+              "from": "vinyl@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+              "dependencies": {
+                "clone": {
+                  "version": "0.2.0",
+                  "from": "clone@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+                },
+                "clone-stats": {
+                  "version": "0.0.1",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
+                  "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gulp-util": {
+      "version": "3.0.4",
+      "from": "gulp-util@>=3.0.2 <3.1.0",
+      "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.4.tgz",
+      "dependencies": {
+        "array-differ": {
+          "version": "1.0.0",
+          "from": "array-differ@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
+        },
+        "array-uniq": {
+          "version": "1.0.2",
+          "from": "array-uniq@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+        },
+        "beeper": {
+          "version": "1.0.0",
+          "from": "beeper@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.0.0.tgz"
+        },
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "dateformat": {
+          "version": "1.0.11",
+          "from": "dateformat@>=1.0.11 <2.0.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "dependencies": {
+            "get-stdin": {
+              "version": "4.0.1",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+            },
+            "meow": {
+              "version": "3.1.0",
+              "from": "meow@*",
+              "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+              "dependencies": {
+                "camelcase-keys": {
+                  "version": "1.0.0",
+                  "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "map-obj": {
+                      "version": "1.0.1",
+                      "from": "map-obj@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                    }
+                  }
+                },
+                "indent-string": {
+                  "version": "1.2.1",
+                  "from": "indent-string@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "1.1.2",
+                      "from": "repeating@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.1",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.0",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "lodash._reescape": {
+          "version": "3.0.0",
+          "from": "lodash._reescape@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz"
+        },
+        "lodash._reevaluate": {
+          "version": "3.0.0",
+          "from": "lodash._reevaluate@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz"
+        },
+        "lodash._reinterpolate": {
+          "version": "3.0.0",
+          "from": "lodash._reinterpolate@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz"
+        },
+        "lodash.template": {
+          "version": "3.6.0",
+          "from": "lodash.template@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.0.tgz",
+          "dependencies": {
+            "lodash._basecopy": {
+              "version": "3.0.1",
+              "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+            },
+            "lodash._basetostring": {
+              "version": "3.0.0",
+              "from": "lodash._basetostring@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.0.tgz"
+            },
+            "lodash._basevalues": {
+              "version": "3.0.0",
+              "from": "lodash._basevalues@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.8",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.8.tgz"
+            },
+            "lodash.escape": {
+              "version": "3.0.0",
+              "from": "lodash.escape@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.0.0.tgz"
+            },
+            "lodash.keys": {
+              "version": "3.1.0",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.0.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            },
+            "lodash.templatesettings": {
+              "version": "3.1.0",
+              "from": "lodash.templatesettings@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.0.tgz"
+            }
+          }
+        },
+        "minimist": {
+          "version": "1.1.1",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+        },
+        "multipipe": {
+          "version": "0.1.2",
+          "from": "multipipe@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+          "dependencies": {
+            "duplexer2": {
+              "version": "0.0.2",
+              "from": "duplexer2@0.0.2",
+              "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "2.0.0",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
+        },
+        "replace-ext": {
+          "version": "0.0.1",
+          "from": "replace-ext@0.0.1",
+          "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <1.0.0-0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.3 <0.5.0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "from": "clone@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "gulp-webpack": {
+      "version": "1.2.0",
+      "from": "gulp-webpack@>=1.2.0 <1.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-webpack/-/gulp-webpack-1.2.0.tgz",
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0-0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+        },
+        "vinyl": {
+          "version": "0.4.6",
+          "from": "vinyl@>=0.4.0 <0.5.0-0",
+          "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
+          "dependencies": {
+            "clone": {
+              "version": "0.2.0",
+              "from": "clone@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
+            },
+            "clone-stats": {
+              "version": "0.0.1",
+              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
+            }
+          }
+        },
+        "through": {
+          "version": "2.3.7",
+          "from": "through@>=2.3.6 <2.4.0",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
+        },
+        "webpack": {
+          "version": "1.5.3",
+          "from": "webpack@>=1.5.0 <1.6.0-0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.5.3.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.0 <1.3.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.4.23",
+              "from": "uglify-js@>=2.4.13 <2.5.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.6 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.34",
+                  "from": "source-map@0.1.34",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "uglify-to-browserify": {
+                  "version": "1.0.2",
+                  "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+                },
+                "yargs": {
+                  "version": "3.5.4",
+                  "from": "yargs@>=3.5.4 <3.6.0",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+                  "dependencies": {
+                    "camelcase": {
+                      "version": "1.1.0",
+                      "from": "camelcase@>=1.0.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                    },
+                    "decamelize": {
+                      "version": "1.0.0",
+                      "from": "decamelize@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                    },
+                    "window-size": {
+                      "version": "0.1.0",
+                      "from": "window-size@0.1.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "enhanced-resolve": {
+              "version": "0.8.6",
+              "from": "enhanced-resolve@>=0.8.2 <0.9.0",
+              "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.6.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                }
+              }
+            },
+            "clone": {
+              "version": "0.1.19",
+              "from": "clone@>=0.1.15 <0.2.0",
+              "resolved": "https://registry.npmjs.org/clone/-/clone-0.1.19.tgz"
+            },
+            "webpack-core": {
+              "version": "0.4.8",
+              "from": "webpack-core@>=0.4.8 <0.5.0",
+              "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.4.8.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.38 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "node-libs-browser": {
+              "version": "0.4.3",
+              "from": "node-libs-browser@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.4.3.tgz",
+              "dependencies": {
+                "assert": {
+                  "version": "1.3.0",
+                  "from": "assert@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+                },
+                "browserify-zlib": {
+                  "version": "0.1.4",
+                  "from": "browserify-zlib@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+                  "dependencies": {
+                    "pako": {
+                      "version": "0.2.6",
+                      "from": "pako@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+                    }
+                  }
+                },
+                "buffer": {
+                  "version": "3.2.2",
+                  "from": "buffer@>=3.0.3 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
+                  "dependencies": {
+                    "base64-js": {
+                      "version": "0.0.8",
+                      "from": "base64-js@0.0.8",
+                      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+                    },
+                    "ieee754": {
+                      "version": "1.1.5",
+                      "from": "ieee754@>=1.1.4 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+                    },
+                    "is-array": {
+                      "version": "1.0.1",
+                      "from": "is-array@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+                    }
+                  }
+                },
+                "console-browserify": {
+                  "version": "1.1.0",
+                  "from": "console-browserify@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+                  "dependencies": {
+                    "date-now": {
+                      "version": "0.1.4",
+                      "from": "date-now@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                    }
+                  }
+                },
+                "constants-browserify": {
+                  "version": "0.0.1",
+                  "from": "constants-browserify@0.0.1",
+                  "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+                },
+                "crypto-browserify": {
+                  "version": "3.2.8",
+                  "from": "crypto-browserify@>=3.2.6 <3.3.0",
+                  "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+                  "dependencies": {
+                    "pbkdf2-compat": {
+                      "version": "2.0.1",
+                      "from": "pbkdf2-compat@2.0.1",
+                      "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                    },
+                    "ripemd160": {
+                      "version": "0.2.0",
+                      "from": "ripemd160@0.2.0",
+                      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                    },
+                    "sha.js": {
+                      "version": "2.2.6",
+                      "from": "sha.js@2.2.6",
+                      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                    }
+                  }
+                },
+                "domain-browser": {
+                  "version": "1.1.4",
+                  "from": "domain-browser@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+                },
+                "events": {
+                  "version": "1.0.2",
+                  "from": "events@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+                },
+                "http-browserify": {
+                  "version": "1.7.0",
+                  "from": "http-browserify@>=1.3.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+                  "dependencies": {
+                    "Base64": {
+                      "version": "0.2.1",
+                      "from": "Base64@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "https-browserify": {
+                  "version": "0.0.0",
+                  "from": "https-browserify@0.0.0",
+                  "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+                },
+                "os-browserify": {
+                  "version": "0.1.2",
+                  "from": "os-browserify@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+                },
+                "path-browserify": {
+                  "version": "0.0.0",
+                  "from": "path-browserify@0.0.0",
+                  "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+                },
+                "process": {
+                  "version": "0.10.1",
+                  "from": "process@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/process/-/process-0.10.1.tgz"
+                },
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@>=1.2.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring-es3": {
+                  "version": "0.2.1",
+                  "from": "querystring-es3@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.13 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "stream-browserify": {
+                  "version": "1.0.0",
+                  "from": "stream-browserify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.25 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "timers-browserify": {
+                  "version": "1.4.1",
+                  "from": "timers-browserify@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz",
+                  "dependencies": {
+                    "process": {
+                      "version": "0.11.1",
+                      "from": "process@>=0.11.0 <0.12.0",
+                      "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+                    }
+                  }
+                },
+                "tty-browserify": {
+                  "version": "0.0.0",
+                  "from": "tty-browserify@0.0.0",
+                  "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+                },
+                "url": {
+                  "version": "0.10.3",
+                  "from": "url@>=0.10.1 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+                  "dependencies": {
+                    "querystring": {
+                      "version": "0.2.0",
+                      "from": "querystring@0.2.0",
+                      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                    }
+                  }
+                },
+                "util": {
+                  "version": "0.10.3",
+                  "from": "util@>=0.10.3 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2.0.1",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "vm-browserify": {
+                  "version": "0.0.4",
+                  "from": "vm-browserify@0.0.4",
+                  "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+                  "dependencies": {
+                    "indexof": {
+                      "version": "0.0.1",
+                      "from": "indexof@0.0.1",
+                      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "watchpack": {
+              "version": "0.2.8",
+              "from": "watchpack@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.8.tgz",
+              "dependencies": {
+                "chokidar": {
+                  "version": "1.0.1",
+                  "from": "chokidar@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
+                  "dependencies": {
+                    "anymatch": {
+                      "version": "1.3.0",
+                      "from": "anymatch@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                      "dependencies": {
+                        "micromatch": {
+                          "version": "2.1.6",
+                          "from": "micromatch@>=2.1.5 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                          "dependencies": {
+                            "arr-diff": {
+                              "version": "1.0.1",
+                              "from": "arr-diff@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                              "dependencies": {
+                                "array-slice": {
+                                  "version": "0.2.3",
+                                  "from": "array-slice@>=0.2.2 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                                }
+                              }
+                            },
+                            "braces": {
+                              "version": "1.8.0",
+                              "from": "braces@>=1.8.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                              "dependencies": {
+                                "expand-range": {
+                                  "version": "1.8.1",
+                                  "from": "expand-range@>=1.8.1 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                                  "dependencies": {
+                                    "fill-range": {
+                                      "version": "2.2.2",
+                                      "from": "fill-range@>=2.1.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "1.1.2",
+                                          "from": "is-number@>=1.1.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                        },
+                                        "isobject": {
+                                          "version": "1.0.0",
+                                          "from": "isobject@>=1.0.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                        },
+                                        "randomatic": {
+                                          "version": "1.1.0",
+                                          "from": "randomatic@>=1.1.0 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                        },
+                                        "repeat-string": {
+                                          "version": "1.5.2",
+                                          "from": "repeat-string@>=1.5.2 <2.0.0",
+                                          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "preserve": {
+                                  "version": "0.2.0",
+                                  "from": "preserve@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                                },
+                                "repeat-element": {
+                                  "version": "1.1.2",
+                                  "from": "repeat-element@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                                }
+                              }
+                            },
+                            "debug": {
+                              "version": "2.2.0",
+                              "from": "debug@>=2.1.3 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "0.7.1",
+                                  "from": "ms@0.7.1",
+                                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                                }
+                              }
+                            },
+                            "expand-brackets": {
+                              "version": "0.1.1",
+                              "from": "expand-brackets@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                            },
+                            "filename-regex": {
+                              "version": "2.0.0",
+                              "from": "filename-regex@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                            },
+                            "kind-of": {
+                              "version": "1.1.0",
+                              "from": "kind-of@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                            },
+                            "object.omit": {
+                              "version": "0.2.1",
+                              "from": "object.omit@>=0.2.1 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                              "dependencies": {
+                                "for-own": {
+                                  "version": "0.1.3",
+                                  "from": "for-own@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                                  "dependencies": {
+                                    "for-in": {
+                                      "version": "0.1.4",
+                                      "from": "for-in@>=0.1.4 <0.2.0",
+                                      "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                    }
+                                  }
+                                },
+                                "isobject": {
+                                  "version": "0.2.0",
+                                  "from": "isobject@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                                }
+                              }
+                            },
+                            "parse-glob": {
+                              "version": "3.0.2",
+                              "from": "parse-glob@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                              "dependencies": {
+                                "glob-base": {
+                                  "version": "0.2.0",
+                                  "from": "glob-base@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                                },
+                                "is-dotfile": {
+                                  "version": "1.0.0",
+                                  "from": "is-dotfile@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                                },
+                                "is-extglob": {
+                                  "version": "1.0.0",
+                                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "regex-cache": {
+                              "version": "0.4.2",
+                              "from": "regex-cache@>=0.4.0 <0.5.0",
+                              "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                              "dependencies": {
+                                "is-equal-shallow": {
+                                  "version": "0.1.2",
+                                  "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+                                  "dependencies": {
+                                    "is-primitive": {
+                                      "version": "1.0.0",
+                                      "from": "is-primitive@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "is-primitive": {
+                                  "version": "2.0.0",
+                                  "from": "is-primitive@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "arrify": {
+                      "version": "1.0.0",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                    },
+                    "async-each": {
+                      "version": "0.1.6",
+                      "from": "async-each@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                    },
+                    "glob-parent": {
+                      "version": "1.2.0",
+                      "from": "glob-parent@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+                    },
+                    "is-binary-path": {
+                      "version": "1.0.0",
+                      "from": "is-binary-path@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                      "dependencies": {
+                        "binary-extensions": {
+                          "version": "1.3.1",
+                          "from": "binary-extensions@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "is-glob": {
+                      "version": "1.1.3",
+                      "from": "is-glob@>=1.1.3 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+                    },
+                    "readdirp": {
+                      "version": "1.3.0",
+                      "from": "readdirp@>=1.3.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "2.0.3",
+                          "from": "graceful-fs@>=2.0.0 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                        },
+                        "minimatch": {
+                          "version": "0.2.14",
+                          "from": "minimatch@>=0.2.12 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                          "dependencies": {
+                            "lru-cache": {
+                              "version": "2.6.4",
+                              "from": "lru-cache@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                            },
+                            "sigmund": {
+                              "version": "1.0.1",
+                              "from": "sigmund@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.1",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "fsevents": {
+                      "version": "0.3.6",
+                      "from": "fsevents@>=0.3.1 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
+                      "dependencies": {
+                        "nan": {
+                          "version": "1.8.4",
+                          "from": "nan@>=1.8.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.2 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                }
+              }
+            },
+            "tapable": {
+              "version": "0.1.9",
+              "from": "tapable@>=0.1.8 <0.2.0",
+              "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "haml": {
+      "version": "0.4.3",
+      "from": "haml@>=0.4.3 <0.5.0",
+      "resolved": "https://registry.npmjs.org/haml/-/haml-0.4.3.tgz"
+    },
+    "handlebars": {
+      "version": "2.0.0",
+      "from": "handlebars@>=2.0.0 <2.1.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@>=2.3.0 <2.4.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "http-proxy": {
+      "version": "1.8.1",
+      "from": "http-proxy@>=1.8.0 <1.9.0",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.8.1.tgz",
+      "dependencies": {
+        "eventemitter3": {
+          "version": "0.1.6",
+          "from": "eventemitter3@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+        },
+        "requires-port": {
+          "version": "0.0.0",
+          "from": "requires-port@>=0.0.0 <1.0.0",
+          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-0.0.0.tgz"
+        }
+      }
+    },
+    "jade": {
+      "version": "1.8.2",
+      "from": "jade@>=1.8.1 <1.9.0",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-1.8.2.tgz",
+      "dependencies": {
+        "character-parser": {
+          "version": "1.2.1",
+          "from": "character-parser@1.2.1",
+          "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
+        },
+        "commander": {
+          "version": "2.5.1",
+          "from": "commander@>=2.5.0 <2.6.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz"
+        },
+        "constantinople": {
+          "version": "3.0.1",
+          "from": "constantinople@>=3.0.1 <3.1.0",
+          "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.0.1.tgz",
+          "dependencies": {
+            "acorn-globals": {
+              "version": "1.0.4",
+              "from": "acorn-globals@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "1.1.0",
+                  "from": "acorn@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "transformers": {
+          "version": "2.1.0",
+          "from": "transformers@2.1.0",
+          "resolved": "https://registry.npmjs.org/transformers/-/transformers-2.1.0.tgz",
+          "dependencies": {
+            "promise": {
+              "version": "2.0.0",
+              "from": "promise@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/promise/-/promise-2.0.0.tgz",
+              "dependencies": {
+                "is-promise": {
+                  "version": "1.0.1",
+                  "from": "is-promise@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz"
+                }
+              }
+            },
+            "css": {
+              "version": "1.0.8",
+              "from": "css@>=1.0.8 <1.1.0",
+              "resolved": "https://registry.npmjs.org/css/-/css-1.0.8.tgz",
+              "dependencies": {
+                "css-parse": {
+                  "version": "1.0.4",
+                  "from": "css-parse@1.0.4",
+                  "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.0.4.tgz"
+                },
+                "css-stringify": {
+                  "version": "1.0.5",
+                  "from": "css-stringify@1.0.5",
+                  "resolved": "https://registry.npmjs.org/css-stringify/-/css-stringify-1.0.5.tgz"
+                }
+              }
+            },
+            "uglify-js": {
+              "version": "2.2.5",
+              "from": "uglify-js@>=2.2.5 <2.3.0",
+              "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.2.5.tgz",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.43",
+                  "from": "source-map@>=0.1.7 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "optimist": {
+                  "version": "0.3.7",
+                  "from": "optimist@>=0.3.5 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.3",
+                      "from": "wordwrap@>=0.0.2 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "void-elements": {
+          "version": "1.0.0",
+          "from": "void-elements@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-1.0.0.tgz"
+        },
+        "with": {
+          "version": "4.0.3",
+          "from": "with@>=4.0.0 <4.1.0",
+          "resolved": "https://registry.npmjs.org/with/-/with-4.0.3.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "1.1.0",
+              "from": "acorn@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.1.0.tgz"
+            },
+            "acorn-globals": {
+              "version": "1.0.4",
+              "from": "acorn-globals@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "jasmine-core": {
+      "version": "2.3.4",
+      "from": "jasmine-core@*",
+      "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+    },
+    "jshint": {
+      "version": "2.7.0",
+      "from": "jshint@>=2.5.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.7.0.tgz",
+      "dependencies": {
+        "cli": {
+          "version": "0.6.6",
+          "from": "cli@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.1 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <1.2.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
+        },
+        "htmlparser2": {
+          "version": "3.8.2",
+          "from": "htmlparser2@>=3.8.0 <3.9.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.2.tgz",
+          "dependencies": {
+            "domhandler": {
+              "version": "2.3.0",
+              "from": "domhandler@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz"
+            },
+            "domutils": {
+              "version": "1.5.1",
+              "from": "domutils@>=1.5.0 <1.6.0",
+              "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+              "dependencies": {
+                "dom-serializer": {
+                  "version": "0.1.0",
+                  "from": "dom-serializer@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.1.3",
+                      "from": "domelementtype@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                    },
+                    "entities": {
+                      "version": "1.1.1",
+                      "from": "entities@>=1.1.1 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domelementtype": {
+              "version": "1.3.0",
+              "from": "domelementtype@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.1.13",
+              "from": "readable-stream@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.0.0",
+              "from": "entities@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz"
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.8",
+          "from": "minimatch@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.0",
+              "from": "brace-expansion@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "0.2.0",
+                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+        },
+        "lodash": {
+          "version": "3.6.0",
+          "from": "lodash@>=3.6.0 <3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.6.0.tgz"
+        }
+      }
+    },
+    "jshint-loader": {
+      "version": "0.8.3",
+      "from": "jshint-loader@>=0.8.3 <0.9.0",
+      "resolved": "https://registry.npmjs.org/jshint-loader/-/jshint-loader-0.8.3.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.9",
+          "from": "loader-utils@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.0.2",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        },
+        "rcloader": {
+          "version": "0.1.2",
+          "from": "rcloader@0.1.2",
+          "resolved": "https://registry.npmjs.org/rcloader/-/rcloader-0.1.2.tgz",
+          "dependencies": {
+            "rcfinder": {
+              "version": "0.1.8",
+              "from": "rcfinder@>=0.1.6 <0.2.0",
+              "resolved": "https://registry.npmjs.org/rcfinder/-/rcfinder-0.1.8.tgz"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <2.5.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "0.1.3",
+          "from": "strip-json-comments@>=0.1.0 <0.2.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+        }
+      }
+    },
+    "jshint-stylish": {
+      "version": "1.0.2",
+      "from": "jshint-stylish@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/jshint-stylish/-/jshint-stylish-1.0.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.0.0",
+          "from": "chalk@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.0.1",
+              "from": "ansi-styles@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.3",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+            },
+            "has-ansi": {
+              "version": "1.0.3",
+              "from": "has-ansi@>=1.0.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                },
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@>=4.0.1 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "1.3.1",
+              "from": "supports-color@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "from": "log-symbols@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz"
+        },
+        "string-length": {
+          "version": "1.0.0",
+          "from": "string-length@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.0.tgz",
+          "dependencies": {
+            "strip-ansi": {
+              "version": "2.0.1",
+              "from": "strip-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "1.1.1",
+                  "from": "ansi-regex@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        }
+      }
+    },
+    "karma": {
+      "version": "0.12.32",
+      "from": "karma@>=0.12.31 <0.13.0",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-0.12.32.tgz",
+      "dependencies": {
+        "di": {
+          "version": "0.0.1",
+          "from": "di@>=0.0.1 <0.1.0",
+          "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz"
+        },
+        "socket.io": {
+          "version": "1.3.5",
+          "from": "socket.io@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.3.5.tgz",
+          "dependencies": {
+            "engine.io": {
+              "version": "1.5.1",
+              "from": "engine.io@1.5.1",
+              "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.5.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.3",
+                  "from": "debug@1.0.3",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "ws": {
+                  "version": "0.5.0",
+                  "from": "ws@0.5.0",
+                  "resolved": "https://registry.npmjs.org/ws/-/ws-0.5.0.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.4.3",
+                      "from": "nan@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.4.3.tgz"
+                    },
+                    "options": {
+                      "version": "0.0.6",
+                      "from": "options@>=0.0.5",
+                      "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                    },
+                    "ultron": {
+                      "version": "1.0.1",
+                      "from": "ultron@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                    }
+                  }
+                },
+                "engine.io-parser": {
+                  "version": "1.2.1",
+                  "from": "engine.io-parser@1.2.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                  "dependencies": {
+                    "after": {
+                      "version": "0.8.1",
+                      "from": "after@0.8.1",
+                      "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                    },
+                    "arraybuffer.slice": {
+                      "version": "0.0.6",
+                      "from": "arraybuffer.slice@0.0.6",
+                      "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                    },
+                    "base64-arraybuffer": {
+                      "version": "0.1.2",
+                      "from": "base64-arraybuffer@0.1.2",
+                      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                    },
+                    "blob": {
+                      "version": "0.0.2",
+                      "from": "blob@0.0.2",
+                      "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                    },
+                    "has-binary": {
+                      "version": "0.1.5",
+                      "from": "has-binary@0.1.5",
+                      "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                      "dependencies": {
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        }
+                      }
+                    },
+                    "utf8": {
+                      "version": "2.0.0",
+                      "from": "utf8@2.0.0",
+                      "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                    }
+                  }
+                },
+                "base64id": {
+                  "version": "0.1.0",
+                  "from": "base64id@0.1.0",
+                  "resolved": "https://registry.npmjs.org/base64id/-/base64id-0.1.0.tgz"
+                }
+              }
+            },
+            "socket.io-parser": {
+              "version": "2.2.4",
+              "from": "socket.io-parser@2.2.4",
+              "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.4.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "json3": {
+                  "version": "3.2.6",
+                  "from": "json3@3.2.6",
+                  "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "benchmark": {
+                  "version": "1.0.0",
+                  "from": "benchmark@1.0.0",
+                  "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                }
+              }
+            },
+            "socket.io-client": {
+              "version": "1.3.5",
+              "from": "socket.io-client@1.3.5",
+              "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.3.5.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "0.7.4",
+                  "from": "debug@0.7.4",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                },
+                "engine.io-client": {
+                  "version": "1.5.1",
+                  "from": "engine.io-client@1.5.1",
+                  "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.5.1.tgz",
+                  "dependencies": {
+                    "has-cors": {
+                      "version": "1.0.3",
+                      "from": "has-cors@1.0.3",
+                      "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.0.3.tgz",
+                      "dependencies": {
+                        "global": {
+                          "version": "2.0.1",
+                          "from": "https://github.com/component/global/archive/v2.0.1.tar.gz",
+                          "resolved": "https://github.com/component/global/archive/v2.0.1.tar.gz"
+                        }
+                      }
+                    },
+                    "ws": {
+                      "version": "0.4.31",
+                      "from": "ws@0.4.31",
+                      "resolved": "https://registry.npmjs.org/ws/-/ws-0.4.31.tgz",
+                      "dependencies": {
+                        "commander": {
+                          "version": "0.6.1",
+                          "from": "commander@>=0.6.1 <0.7.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                        },
+                        "nan": {
+                          "version": "0.3.2",
+                          "from": "nan@>=0.3.0 <0.4.0",
+                          "resolved": "https://registry.npmjs.org/nan/-/nan-0.3.2.tgz"
+                        },
+                        "tinycolor": {
+                          "version": "0.0.1",
+                          "from": "tinycolor@>=0.0.0 <1.0.0",
+                          "resolved": "https://registry.npmjs.org/tinycolor/-/tinycolor-0.0.1.tgz"
+                        },
+                        "options": {
+                          "version": "0.0.6",
+                          "from": "options@>=0.0.5",
+                          "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
+                        }
+                      }
+                    },
+                    "xmlhttprequest": {
+                      "version": "1.5.0",
+                      "from": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz",
+                      "resolved": "https://github.com/rase-/node-XMLHttpRequest/archive/a6b6f2.tar.gz"
+                    },
+                    "engine.io-parser": {
+                      "version": "1.2.1",
+                      "from": "engine.io-parser@1.2.1",
+                      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.2.1.tgz",
+                      "dependencies": {
+                        "after": {
+                          "version": "0.8.1",
+                          "from": "after@0.8.1",
+                          "resolved": "https://registry.npmjs.org/after/-/after-0.8.1.tgz"
+                        },
+                        "arraybuffer.slice": {
+                          "version": "0.0.6",
+                          "from": "arraybuffer.slice@0.0.6",
+                          "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz"
+                        },
+                        "base64-arraybuffer": {
+                          "version": "0.1.2",
+                          "from": "base64-arraybuffer@0.1.2",
+                          "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz"
+                        },
+                        "blob": {
+                          "version": "0.0.2",
+                          "from": "blob@0.0.2",
+                          "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.2.tgz"
+                        },
+                        "has-binary": {
+                          "version": "0.1.5",
+                          "from": "has-binary@0.1.5",
+                          "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.5.tgz",
+                          "dependencies": {
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            }
+                          }
+                        },
+                        "utf8": {
+                          "version": "2.0.0",
+                          "from": "utf8@2.0.0",
+                          "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "1.0.4",
+                      "from": "debug@1.0.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.6.2",
+                          "from": "ms@0.6.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                        }
+                      }
+                    },
+                    "parseuri": {
+                      "version": "0.0.4",
+                      "from": "parseuri@0.0.4",
+                      "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.4.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parsejson": {
+                      "version": "0.0.1",
+                      "from": "parsejson@0.0.1",
+                      "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.1.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "parseqs": {
+                      "version": "0.0.2",
+                      "from": "parseqs@0.0.2",
+                      "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.2.tgz",
+                      "dependencies": {
+                        "better-assert": {
+                          "version": "1.0.2",
+                          "from": "better-assert@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                          "dependencies": {
+                            "callsite": {
+                              "version": "1.0.0",
+                              "from": "callsite@1.0.0",
+                              "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "component-inherit": {
+                      "version": "0.0.3",
+                      "from": "component-inherit@0.0.3",
+                      "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz"
+                    }
+                  }
+                },
+                "component-bind": {
+                  "version": "1.0.0",
+                  "from": "component-bind@1.0.0",
+                  "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz"
+                },
+                "component-emitter": {
+                  "version": "1.1.2",
+                  "from": "component-emitter@1.1.2",
+                  "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                },
+                "object-component": {
+                  "version": "0.0.3",
+                  "from": "object-component@0.0.3",
+                  "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz"
+                },
+                "has-binary": {
+                  "version": "0.1.6",
+                  "from": "has-binary@0.1.6",
+                  "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.6.tgz",
+                  "dependencies": {
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    }
+                  }
+                },
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                },
+                "parseuri": {
+                  "version": "0.0.2",
+                  "from": "parseuri@0.0.2",
+                  "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.2.tgz",
+                  "dependencies": {
+                    "better-assert": {
+                      "version": "1.0.2",
+                      "from": "better-assert@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+                      "dependencies": {
+                        "callsite": {
+                          "version": "1.0.0",
+                          "from": "callsite@1.0.0",
+                          "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "to-array": {
+                  "version": "0.1.3",
+                  "from": "to-array@0.1.3",
+                  "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.3.tgz"
+                },
+                "backo2": {
+                  "version": "1.0.2",
+                  "from": "backo2@1.0.2",
+                  "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz"
+                }
+              }
+            },
+            "socket.io-adapter": {
+              "version": "0.3.1",
+              "from": "socket.io-adapter@0.3.1",
+              "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.3.1.tgz",
+              "dependencies": {
+                "debug": {
+                  "version": "1.0.2",
+                  "from": "debug@1.0.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.2.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    }
+                  }
+                },
+                "socket.io-parser": {
+                  "version": "2.2.2",
+                  "from": "socket.io-parser@2.2.2",
+                  "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.2.2.tgz",
+                  "dependencies": {
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "json3": {
+                      "version": "3.2.6",
+                      "from": "json3@3.2.6",
+                      "resolved": "https://registry.npmjs.org/json3/-/json3-3.2.6.tgz"
+                    },
+                    "component-emitter": {
+                      "version": "1.1.2",
+                      "from": "component-emitter@1.1.2",
+                      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "benchmark": {
+                      "version": "1.0.0",
+                      "from": "benchmark@1.0.0",
+                      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-1.0.0.tgz"
+                    }
+                  }
+                },
+                "object-keys": {
+                  "version": "1.0.1",
+                  "from": "object-keys@1.0.1",
+                  "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.1.tgz"
+                }
+              }
+            },
+            "has-binary-data": {
+              "version": "0.1.3",
+              "from": "has-binary-data@0.1.3",
+              "resolved": "https://registry.npmjs.org/has-binary-data/-/has-binary-data-0.1.3.tgz",
+              "dependencies": {
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "2.1.0",
+              "from": "debug@2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "chokidar": {
+          "version": "1.0.1",
+          "from": "chokidar@>=0.8.2",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
+          "dependencies": {
+            "anymatch": {
+              "version": "1.3.0",
+              "from": "anymatch@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+              "dependencies": {
+                "micromatch": {
+                  "version": "2.1.6",
+                  "from": "micromatch@>=2.1.5 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                  "dependencies": {
+                    "arr-diff": {
+                      "version": "1.0.1",
+                      "from": "arr-diff@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                      "dependencies": {
+                        "array-slice": {
+                          "version": "0.2.3",
+                          "from": "array-slice@>=0.2.2 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                        }
+                      }
+                    },
+                    "braces": {
+                      "version": "1.8.0",
+                      "from": "braces@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                      "dependencies": {
+                        "expand-range": {
+                          "version": "1.8.1",
+                          "from": "expand-range@>=1.8.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                          "dependencies": {
+                            "fill-range": {
+                              "version": "2.2.2",
+                              "from": "fill-range@>=2.1.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "1.1.2",
+                                  "from": "is-number@>=1.1.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                },
+                                "isobject": {
+                                  "version": "1.0.0",
+                                  "from": "isobject@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                },
+                                "randomatic": {
+                                  "version": "1.1.0",
+                                  "from": "randomatic@>=1.1.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                },
+                                "repeat-string": {
+                                  "version": "1.5.2",
+                                  "from": "repeat-string@>=1.5.2 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "preserve": {
+                          "version": "0.2.0",
+                          "from": "preserve@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                        },
+                        "repeat-element": {
+                          "version": "1.1.2",
+                          "from": "repeat-element@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "2.2.0",
+                      "from": "debug@*",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.1",
+                          "from": "ms@0.7.1",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                        }
+                      }
+                    },
+                    "expand-brackets": {
+                      "version": "0.1.1",
+                      "from": "expand-brackets@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                    },
+                    "filename-regex": {
+                      "version": "2.0.0",
+                      "from": "filename-regex@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                    },
+                    "kind-of": {
+                      "version": "1.1.0",
+                      "from": "kind-of@>=1.1.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                    },
+                    "object.omit": {
+                      "version": "0.2.1",
+                      "from": "object.omit@>=0.2.1 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                      "dependencies": {
+                        "for-own": {
+                          "version": "0.1.3",
+                          "from": "for-own@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                          "dependencies": {
+                            "for-in": {
+                              "version": "0.1.4",
+                              "from": "for-in@>=0.1.4 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                            }
+                          }
+                        },
+                        "isobject": {
+                          "version": "0.2.0",
+                          "from": "isobject@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                        }
+                      }
+                    },
+                    "parse-glob": {
+                      "version": "3.0.2",
+                      "from": "parse-glob@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                      "dependencies": {
+                        "glob-base": {
+                          "version": "0.2.0",
+                          "from": "glob-base@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                        },
+                        "is-dotfile": {
+                          "version": "1.0.0",
+                          "from": "is-dotfile@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "regex-cache": {
+                      "version": "0.4.2",
+                      "from": "regex-cache@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                      "dependencies": {
+                        "is-equal-shallow": {
+                          "version": "0.1.2",
+                          "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+                          "dependencies": {
+                            "is-primitive": {
+                              "version": "1.0.0",
+                              "from": "is-primitive@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "is-primitive": {
+                          "version": "2.0.0",
+                          "from": "is-primitive@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.0",
+              "from": "arrify@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+            },
+            "async-each": {
+              "version": "0.1.6",
+              "from": "async-each@>=0.1.5 <0.2.0",
+              "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+            },
+            "glob-parent": {
+              "version": "1.2.0",
+              "from": "glob-parent@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+            },
+            "is-binary-path": {
+              "version": "1.0.0",
+              "from": "is-binary-path@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+              "dependencies": {
+                "binary-extensions": {
+                  "version": "1.3.1",
+                  "from": "binary-extensions@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "1.1.3",
+              "from": "is-glob@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+            },
+            "readdirp": {
+              "version": "1.3.0",
+              "from": "readdirp@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.0.33",
+                  "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "fsevents": {
+              "version": "0.3.6",
+              "from": "fsevents@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
+              "dependencies": {
+                "nan": {
+                  "version": "1.8.4",
+                  "from": "nan@>=1.8.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "glob": {
+          "version": "3.2.11",
+          "from": "glob@>=3.2.7 <3.3.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "0.3.0",
+              "from": "minimatch@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "expand-braces": {
+          "version": "0.1.1",
+          "from": "expand-braces@>=0.1.1 <0.2.0",
+          "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.1.tgz",
+          "dependencies": {
+            "array-slice": {
+              "version": "0.2.3",
+              "from": "array-slice@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+            },
+            "array-uniq": {
+              "version": "1.0.2",
+              "from": "array-uniq@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+            },
+            "braces": {
+              "version": "0.1.5",
+              "from": "braces@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+              "dependencies": {
+                "expand-range": {
+                  "version": "0.1.1",
+                  "from": "expand-range@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+                  "dependencies": {
+                    "is-number": {
+                      "version": "0.1.1",
+                      "from": "is-number@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz"
+                    },
+                    "repeat-string": {
+                      "version": "0.2.2",
+                      "from": "repeat-string@>=0.2.2 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "http-proxy": {
+          "version": "0.10.4",
+          "from": "http-proxy@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-0.10.4.tgz",
+          "dependencies": {
+            "pkginfo": {
+              "version": "0.3.0",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+            },
+            "utile": {
+              "version": "0.2.1",
+              "from": "utile@>=0.2.1 <0.3.0",
+              "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@>=0.2.9 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "deep-equal": {
+                  "version": "1.0.0",
+                  "from": "deep-equal@*",
+                  "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
+                },
+                "i": {
+                  "version": "0.3.3",
+                  "from": "i@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.0.0 <1.0.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "ncp": {
+                  "version": "0.4.2",
+                  "from": "ncp@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@>=2.2.5 <2.3.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        },
+        "q": {
+          "version": "0.9.7",
+          "from": "q@>=0.9.7 <0.10.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-0.9.7.tgz"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <2.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@>=1.2.11 <1.3.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "log4js": {
+          "version": "0.6.25",
+          "from": "log4js@>=0.6.3 <0.7.0",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.25.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "semver": {
+              "version": "4.3.4",
+              "from": "semver@>=4.3.3 <4.4.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+            },
+            "underscore": {
+              "version": "1.8.2",
+              "from": "underscore@1.8.2",
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.2.tgz"
+            }
+          }
+        },
+        "useragent": {
+          "version": "2.0.10",
+          "from": "useragent@>=2.0.4 <2.1.0",
+          "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.0.10.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.2.4",
+              "from": "lru-cache@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz"
+            }
+          }
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "from": "graceful-fs@>=2.0.1 <2.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+        },
+        "connect": {
+          "version": "2.26.6",
+          "from": "connect@>=2.26.0 <2.27.0",
+          "resolved": "https://registry.npmjs.org/connect/-/connect-2.26.6.tgz",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0",
+              "resolved": "https://registry.npmjs.org/basic-auth-connect/-/basic-auth-connect-1.0.0.tgz"
+            },
+            "body-parser": {
+              "version": "1.8.4",
+              "from": "body-parser@>=1.8.4 <1.9.0",
+              "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.8.4.tgz",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.4",
+                  "from": "iconv-lite@0.4.4",
+                  "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.4.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                },
+                "raw-body": {
+                  "version": "1.3.0",
+                  "from": "raw-body@1.3.0",
+                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.3.0.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "1.0.0",
+              "from": "bytes@1.0.0",
+              "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz"
+            },
+            "cookie": {
+              "version": "0.1.2",
+              "from": "cookie@0.1.2",
+              "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+            },
+            "cookie-parser": {
+              "version": "1.3.5",
+              "from": "cookie-parser@>=1.3.3 <1.4.0",
+              "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.3.5.tgz",
+              "dependencies": {
+                "cookie": {
+                  "version": "0.1.3",
+                  "from": "cookie@0.1.3",
+                  "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+                },
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "from": "cookie-signature@1.0.6",
+                  "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                }
+              }
+            },
+            "cookie-signature": {
+              "version": "1.0.5",
+              "from": "cookie-signature@1.0.5",
+              "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+            },
+            "compression": {
+              "version": "1.1.2",
+              "from": "compression@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/compression/-/compression-1.1.2.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.2 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.12",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.10.0",
+                          "from": "mime-db@>=1.10.0 <1.11.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "compressible": {
+                  "version": "2.0.2",
+                  "from": "compressible@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.2.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.3.0",
+              "from": "connect-timeout@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/connect-timeout/-/connect-timeout-1.3.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "csurf": {
+              "version": "1.6.6",
+              "from": "csurf@>=1.6.2 <1.7.0",
+              "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.6.6.tgz",
+              "dependencies": {
+                "csrf": {
+                  "version": "2.0.7",
+                  "from": "csrf@>=2.0.5 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-2.0.7.tgz",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    },
+                    "rndm": {
+                      "version": "1.1.0",
+                      "from": "rndm@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.0.tgz"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0",
+                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                    },
+                    "uid-safe": {
+                      "version": "1.1.0",
+                      "from": "uid-safe@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.1.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.1.2",
+                          "from": "native-or-bluebird@>=1.1.2 <1.2.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.1.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "http-errors": {
+                  "version": "1.2.8",
+                  "from": "http-errors@>=1.2.8 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.2.8.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.0.0",
+              "from": "debug@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.0.0.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "0.4.5",
+              "from": "depd@0.4.5",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-0.4.5.tgz"
+            },
+            "errorhandler": {
+              "version": "1.2.4",
+              "from": "errorhandler@>=1.2.2 <1.3.0",
+              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.2.4.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.3 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.12",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.10.0",
+                          "from": "mime-db@>=1.10.0 <1.11.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "express-session": {
+              "version": "1.8.2",
+              "from": "express-session@>=1.8.2 <1.9.0",
+              "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.8.2.tgz",
+              "dependencies": {
+                "crc": {
+                  "version": "3.0.0",
+                  "from": "crc@3.0.0",
+                  "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                },
+                "uid-safe": {
+                  "version": "1.0.1",
+                  "from": "uid-safe@1.0.1",
+                  "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-1.0.1.tgz",
+                  "dependencies": {
+                    "mz": {
+                      "version": "1.3.0",
+                      "from": "mz@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mz/-/mz-1.3.0.tgz",
+                      "dependencies": {
+                        "native-or-bluebird": {
+                          "version": "1.2.0",
+                          "from": "native-or-bluebird@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/native-or-bluebird/-/native-or-bluebird-1.2.0.tgz"
+                        },
+                        "thenify": {
+                          "version": "3.1.0",
+                          "from": "thenify@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.1.0.tgz"
+                        },
+                        "thenify-all": {
+                          "version": "1.6.0",
+                          "from": "thenify-all@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz"
+                        }
+                      }
+                    },
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.2.0",
+              "from": "finalhandler@0.2.0",
+              "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.2.0.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.2.4",
+              "from": "fresh@0.2.4",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+            },
+            "media-typer": {
+              "version": "0.3.0",
+              "from": "media-typer@0.3.0",
+              "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+            },
+            "method-override": {
+              "version": "2.2.0",
+              "from": "method-override@>=2.2.0 <2.3.0",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.2.0.tgz",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.0",
+                  "from": "methods@1.1.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.0.tgz"
+                },
+                "vary": {
+                  "version": "1.0.0",
+                  "from": "vary@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.3.2",
+              "from": "morgan@>=1.3.2 <1.4.0",
+              "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.3.2.tgz",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.0",
+                  "from": "basic-auth@1.0.0",
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.0.tgz"
+                },
+                "on-finished": {
+                  "version": "2.1.0",
+                  "from": "on-finished@2.1.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.0.5",
+                      "from": "ee-first@1.0.5",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "multiparty": {
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@>=1.1.9 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.1",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/stream-counter/-/stream-counter-0.2.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.0",
+              "from": "on-headers@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+            },
+            "parseurl": {
+              "version": "1.3.0",
+              "from": "parseurl@>=1.3.0 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+            },
+            "qs": {
+              "version": "2.2.4",
+              "from": "qs@2.2.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-2.2.4.tgz"
+            },
+            "response-time": {
+              "version": "2.0.1",
+              "from": "response-time@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.0.1.tgz"
+            },
+            "serve-favicon": {
+              "version": "2.1.7",
+              "from": "serve-favicon@>=2.1.5 <2.2.0",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.1.7.tgz",
+              "dependencies": {
+                "etag": {
+                  "version": "1.5.1",
+                  "from": "etag@>=1.5.0 <1.6.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+                  "dependencies": {
+                    "crc": {
+                      "version": "3.2.1",
+                      "from": "crc@3.2.1",
+                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+                    }
+                  }
+                },
+                "ms": {
+                  "version": "0.6.2",
+                  "from": "ms@0.6.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.2.1",
+              "from": "serve-index@>=1.2.1 <1.3.0",
+              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.2.1.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.1.4",
+                  "from": "accepts@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.1.4.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.0.12",
+                      "from": "mime-types@>=2.0.4 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.10.0",
+                          "from": "mime-db@>=1.10.0 <1.11.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.4.9",
+                      "from": "negotiator@0.4.9",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.4.9.tgz"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.1",
+                  "from": "batch@0.5.1",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.1.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.6.5",
+              "from": "serve-static@>=1.6.4 <1.7.0",
+              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.6.5.tgz",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.1",
+                  "from": "escape-html@1.0.1",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+                },
+                "send": {
+                  "version": "0.9.3",
+                  "from": "send@0.9.3",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.9.3.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.3",
+                      "from": "destroy@1.0.3",
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                    },
+                    "etag": {
+                      "version": "1.4.0",
+                      "from": "etag@>=1.4.0 <1.5.0",
+                      "resolved": "https://registry.npmjs.org/etag/-/etag-1.4.0.tgz",
+                      "dependencies": {
+                        "crc": {
+                          "version": "3.0.0",
+                          "from": "crc@3.0.0",
+                          "resolved": "https://registry.npmjs.org/crc/-/crc-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "ms": {
+                      "version": "0.6.2",
+                      "from": "ms@0.6.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.1.0",
+                      "from": "on-finished@2.1.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.1.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.0.5",
+                          "from": "ee-first@1.0.5",
+                          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.0.5.tgz"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.2",
+                      "from": "range-parser@>=1.0.2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.5.7",
+              "from": "type-is@>=1.5.2 <1.6.0",
+              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.0.12",
+                  "from": "mime-types@>=2.0.9 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.1.2 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "vhost": {
+              "version": "3.0.0",
+              "from": "vhost@>=3.0.0 <3.1.0",
+              "resolved": "https://registry.npmjs.org/vhost/-/vhost-3.0.0.tgz"
+            },
+            "pause": {
+              "version": "0.0.1",
+              "from": "pause@0.0.1",
+              "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
+            }
+          }
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.31 <0.2.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        },
+        "memoizee": {
+          "version": "0.3.8",
+          "from": "memoizee@>=0.3.8 <0.4.0",
+          "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "from": "d@>=0.1.1 <0.2.0",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+            },
+            "es5-ext": {
+              "version": "0.10.7",
+              "from": "es5-ext@>=0.10.4 <0.11.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "0.1.4",
+              "from": "es6-weak-map@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.3",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
+                },
+                "es6-symbol": {
+                  "version": "2.0.1",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
+                }
+              }
+            },
+            "event-emitter": {
+              "version": "0.3.3",
+              "from": "event-emitter@>=0.3.1 <0.4.0",
+              "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
+            },
+            "lru-queue": {
+              "version": "0.1.0",
+              "from": "lru-queue@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+            },
+            "next-tick": {
+              "version": "0.2.2",
+              "from": "next-tick@>=0.2.2 <0.3.0",
+              "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+            },
+            "timers-ext": {
+              "version": "0.1.0",
+              "from": "timers-ext@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "karma-angular-filesort": {
+      "version": "0.1.0",
+      "from": "karma-angular-filesort@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-angular-filesort/-/karma-angular-filesort-0.1.0.tgz",
+      "dependencies": {
+        "minimatch": {
+          "version": "1.0.0",
+          "from": "minimatch@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "ng-dependencies": {
+          "version": "0.1.3",
+          "from": "ng-dependencies@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/ng-dependencies/-/ng-dependencies-0.1.3.tgz",
+          "dependencies": {
+            "esprima": {
+              "version": "1.2.5",
+              "from": "esprima@>=1.2.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+            },
+            "sugar": {
+              "version": "1.4.1",
+              "from": "sugar@>=1.4.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/sugar/-/sugar-1.4.1.tgz"
+            },
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "estraverse@>=1.5.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            }
+          }
+        },
+        "q": {
+          "version": "1.4.1",
+          "from": "q@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+        },
+        "toposort": {
+          "version": "0.2.10",
+          "from": "toposort@>=0.2.10 <0.3.0",
+          "resolved": "https://registry.npmjs.org/toposort/-/toposort-0.2.10.tgz"
+        }
+      }
+    },
+    "karma-chrome-launcher": {
+      "version": "0.1.12",
+      "from": "karma-chrome-launcher@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-0.1.12.tgz",
+      "dependencies": {
+        "which": {
+          "version": "1.1.1",
+          "from": "which@>=1.0.9 <2.0.0",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.1.1.tgz",
+          "dependencies": {
+            "is-absolute": {
+              "version": "0.1.7",
+              "from": "is-absolute@>=0.1.7 <0.2.0",
+              "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.1.7.tgz",
+              "dependencies": {
+                "is-relative": {
+                  "version": "0.1.3",
+                  "from": "is-relative@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.1.3.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "karma-jasmine": {
+      "version": "0.3.5",
+      "from": "karma-jasmine@>=0.3.1 <0.4.0",
+      "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-0.3.5.tgz"
+    },
+    "karma-ng-html2js-preprocessor": {
+      "version": "0.1.2",
+      "from": "karma-ng-html2js-preprocessor@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-ng-html2js-preprocessor/-/karma-ng-html2js-preprocessor-0.1.2.tgz"
+    },
+    "karma-phantomjs-launcher": {
+      "version": "0.1.4",
+      "from": "karma-phantomjs-launcher@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/karma-phantomjs-launcher/-/karma-phantomjs-launcher-0.1.4.tgz",
+      "dependencies": {
+        "phantomjs": {
+          "version": "1.9.17",
+          "from": "phantomjs@>=1.9.0 <1.10.0",
+          "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.17.tgz",
+          "dependencies": {
+            "adm-zip": {
+              "version": "0.4.4",
+              "from": "adm-zip@0.4.4",
+              "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+            },
+            "fs-extra": {
+              "version": "0.18.3",
+              "from": "fs-extra@>=0.18.0 <0.19.0",
+              "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.18.3.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.5 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+                },
+                "jsonfile": {
+                  "version": "2.0.0",
+                  "from": "jsonfile@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.0.0.tgz"
+                },
+                "rimraf": {
+                  "version": "2.3.4",
+                  "from": "rimraf@>=2.2.8 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "4.5.3",
+                      "from": "glob@>=4.4.2 <5.0.0",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        },
+                        "minimatch": {
+                          "version": "2.0.8",
+                          "from": "minimatch@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                          "dependencies": {
+                            "brace-expansion": {
+                              "version": "1.1.0",
+                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                              "dependencies": {
+                                "balanced-match": {
+                                  "version": "0.2.0",
+                                  "from": "balanced-match@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                                },
+                                "concat-map": {
+                                  "version": "0.0.1",
+                                  "from": "concat-map@0.0.1",
+                                  "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "once": {
+                          "version": "1.3.2",
+                          "from": "once@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "kew": {
+              "version": "0.4.0",
+              "from": "kew@0.4.0",
+              "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
+            },
+            "npmconf": {
+              "version": "2.1.1",
+              "from": "npmconf@2.1.1",
+              "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+              "dependencies": {
+                "config-chain": {
+                  "version": "1.1.8",
+                  "from": "config-chain@>=1.1.8 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.8.tgz",
+                  "dependencies": {
+                    "proto-list": {
+                      "version": "1.2.4",
+                      "from": "proto-list@>=1.2.1 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "ini": {
+                  "version": "1.3.3",
+                  "from": "ini@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.3.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "nopt": {
+                  "version": "3.0.2",
+                  "from": "nopt@>=3.0.1 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.2.tgz",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.6",
+                      "from": "abbrev@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.6.tgz"
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "osenv": {
+                  "version": "0.1.1",
+                  "from": "osenv@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                },
+                "semver": {
+                  "version": "4.3.4",
+                  "from": "semver@>=4.1.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.4.tgz"
+                },
+                "uid-number": {
+                  "version": "0.0.5",
+                  "from": "uid-number@0.0.5",
+                  "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
+                }
+              }
+            },
+            "progress": {
+              "version": "1.1.8",
+              "from": "progress@1.1.8",
+              "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+            },
+            "request": {
+              "version": "2.42.0",
+              "from": "request@2.42.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.6.0",
+                  "from": "caseless@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                },
+                "qs": {
+                  "version": "1.2.2",
+                  "from": "qs@>=1.2.0 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+                },
+                "node-uuid": {
+                  "version": "1.4.3",
+                  "from": "node-uuid@>=1.4.0 <1.5.0",
+                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.1.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.1.0.tgz"
+                },
+                "form-data": {
+                  "version": "0.1.4",
+                  "from": "form-data@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@>=0.0.4 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5",
+                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@>=1.2.11 <1.3.0",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.4.0",
+                  "from": "oauth-sign@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@>=0.9.0 <0.10.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@>=0.4.0 <0.5.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                }
+              }
+            },
+            "request-progress": {
+              "version": "0.3.1",
+              "from": "request-progress@0.3.1",
+              "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+              "dependencies": {
+                "throttleit": {
+                  "version": "0.0.2",
+                  "from": "throttleit@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.0.9",
+              "from": "which@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+            }
+          }
+        }
+      }
+    },
+    "lodash": {
+      "version": "3.2.0",
+      "from": "lodash@>=3.2.0 <3.3.0",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz"
+    },
+    "main-bower-files": {
+      "version": "2.5.0",
+      "from": "main-bower-files@>=2.5.0 <2.6.0",
+      "resolved": "https://registry.npmjs.org/main-bower-files/-/main-bower-files-2.5.0.tgz",
+      "dependencies": {
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@>=0.6.2 <0.7.0",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.0.3 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "globule": {
+          "version": "0.2.0",
+          "from": "globule@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/globule/-/globule-0.2.0.tgz",
+          "dependencies": {
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@>=2.4.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+            },
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@>=3.2.7 <3.3.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@>=0.3.0 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "minimatch": {
+              "version": "0.2.14",
+              "from": "minimatch@>=0.2.11 <0.3.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.6.4",
+                  "from": "lru-cache@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.1",
+                  "from": "sigmund@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "from": "minimatch@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.6.4",
+              "from": "lru-cache@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+            }
+          }
+        },
+        "strip-json-comments": {
+          "version": "1.0.2",
+          "from": "strip-json-comments@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
+        }
+      }
+    },
+    "merge-stream": {
+      "version": "0.1.7",
+      "from": "merge-stream@>=0.1.7 <0.2.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-0.1.7.tgz",
+      "dependencies": {
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "0.5.2",
+      "from": "node-libs-browser@>=0.4.0 <=0.6.0",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.5.2.tgz",
+      "dependencies": {
+        "assert": {
+          "version": "1.3.0",
+          "from": "assert@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz"
+        },
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "from": "browserify-zlib@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "dependencies": {
+            "pako": {
+              "version": "0.2.6",
+              "from": "pako@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.6.tgz"
+            }
+          }
+        },
+        "buffer": {
+          "version": "3.2.2",
+          "from": "buffer@>=3.0.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-3.2.2.tgz",
+          "dependencies": {
+            "base64-js": {
+              "version": "0.0.8",
+              "from": "base64-js@0.0.8",
+              "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
+            },
+            "ieee754": {
+              "version": "1.1.5",
+              "from": "ieee754@>=1.1.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+            },
+            "is-array": {
+              "version": "1.0.1",
+              "from": "is-array@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/is-array/-/is-array-1.0.1.tgz"
+            }
+          }
+        },
+        "console-browserify": {
+          "version": "1.1.0",
+          "from": "console-browserify@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+          "dependencies": {
+            "date-now": {
+              "version": "0.1.4",
+              "from": "date-now@>=0.1.4 <0.2.0",
+              "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+            }
+          }
+        },
+        "constants-browserify": {
+          "version": "0.0.1",
+          "from": "constants-browserify@0.0.1",
+          "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-0.0.1.tgz"
+        },
+        "crypto-browserify": {
+          "version": "3.2.8",
+          "from": "crypto-browserify@>=3.2.6 <3.3.0",
+          "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.2.8.tgz",
+          "dependencies": {
+            "pbkdf2-compat": {
+              "version": "2.0.1",
+              "from": "pbkdf2-compat@2.0.1",
+              "resolved": "https://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+            },
+            "ripemd160": {
+              "version": "0.2.0",
+              "from": "ripemd160@0.2.0",
+              "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+            },
+            "sha.js": {
+              "version": "2.2.6",
+              "from": "sha.js@2.2.6",
+              "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+            }
+          }
+        },
+        "domain-browser": {
+          "version": "1.1.4",
+          "from": "domain-browser@>=1.1.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.4.tgz"
+        },
+        "events": {
+          "version": "1.0.2",
+          "from": "events@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.0.2.tgz"
+        },
+        "http-browserify": {
+          "version": "1.7.0",
+          "from": "http-browserify@>=1.3.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/http-browserify/-/http-browserify-1.7.0.tgz",
+          "dependencies": {
+            "Base64": {
+              "version": "0.2.1",
+              "from": "Base64@>=0.2.0 <0.3.0",
+              "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "https-browserify": {
+          "version": "0.0.0",
+          "from": "https-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.0.tgz"
+        },
+        "os-browserify": {
+          "version": "0.1.2",
+          "from": "os-browserify@>=0.1.2 <0.2.0",
+          "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.1.2.tgz"
+        },
+        "path-browserify": {
+          "version": "0.0.0",
+          "from": "path-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+        },
+        "process": {
+          "version": "0.11.1",
+          "from": "process@>=0.11.0 <0.12.0",
+          "resolved": "https://registry.npmjs.org/process/-/process-0.11.1.tgz"
+        },
+        "punycode": {
+          "version": "1.3.2",
+          "from": "punycode@>=1.2.4 <2.0.0",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+        },
+        "querystring-es3": {
+          "version": "0.2.1",
+          "from": "querystring-es3@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.13",
+          "from": "readable-stream@>=1.1.13 <2.0.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "stream-browserify": {
+          "version": "1.0.0",
+          "from": "stream-browserify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-1.0.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.25 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        },
+        "timers-browserify": {
+          "version": "1.4.1",
+          "from": "timers-browserify@>=1.0.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.1.tgz"
+        },
+        "tty-browserify": {
+          "version": "0.0.0",
+          "from": "tty-browserify@0.0.0",
+          "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+        },
+        "url": {
+          "version": "0.10.3",
+          "from": "url@>=0.10.1 <0.11.0",
+          "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+          "dependencies": {
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            }
+          }
+        },
+        "util": {
+          "version": "0.10.3",
+          "from": "util@>=0.10.3 <0.11.0",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        },
+        "vm-browserify": {
+          "version": "0.0.4",
+          "from": "vm-browserify@0.0.4",
+          "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+          "dependencies": {
+            "indexof": {
+              "version": "0.0.1",
+              "from": "indexof@0.0.1",
+              "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "qrcode-terminal": {
+      "version": "0.9.5",
+      "from": "qrcode-terminal@>=0.9.5 <0.10.0",
+      "resolved": "https://registry.npmjs.org/qrcode-terminal/-/qrcode-terminal-0.9.5.tgz"
+    },
+    "require-dir": {
+      "version": "0.1.0",
+      "from": "require-dir@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/require-dir/-/require-dir-0.1.0.tgz"
+    },
+    "traceur-loader": {
+      "version": "0.6.3",
+      "from": "traceur-loader@>=0.6.3 <0.7.0",
+      "resolved": "https://registry.npmjs.org/traceur-loader/-/traceur-loader-0.6.3.tgz",
+      "dependencies": {
+        "extend-object": {
+          "version": "1.0.0",
+          "from": "extend-object@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/extend-object/-/extend-object-1.0.0.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.9",
+          "from": "loader-utils@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.0.2",
+              "from": "big.js@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@>=0.4.0 <0.5.0",
+              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
+            }
+          }
+        },
+        "traceur": {
+          "version": "0.0.72",
+          "from": "traceur@0.0.72",
+          "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.72.tgz",
+          "dependencies": {
+            "commander": {
+              "version": "2.8.1",
+              "from": "commander@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+              "dependencies": {
+                "graceful-readlink": {
+                  "version": "1.0.1",
+                  "from": "graceful-readlink@>=1.0.0",
+                  "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                }
+              }
+            },
+            "glob": {
+              "version": "4.5.3",
+              "from": "glob@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                },
+                "minimatch": {
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.0",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.2.0",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "regexpu": {
+              "version": "0.3.0",
+              "from": "regexpu@0.3.0",
+              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-0.3.0.tgz",
+              "dependencies": {
+                "recast": {
+                  "version": "0.8.8",
+                  "from": "recast@>=0.8.0 <0.9.0",
+                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.8.8.tgz",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "7001.1.0-dev-harmony-fb",
+                      "from": "esprima-fb@>=7001.1.0-dev-harmony-fb <7001.2.0",
+                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz"
+                    },
+                    "source-map": {
+                      "version": "0.1.32",
+                      "from": "source-map@0.1.32",
+                      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                      "dependencies": {
+                        "amdefine": {
+                          "version": "0.1.0",
+                          "from": "amdefine@>=0.0.4",
+                          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                        }
+                      }
+                    },
+                    "private": {
+                      "version": "0.1.6",
+                      "from": "private@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                    },
+                    "cls": {
+                      "version": "0.1.5",
+                      "from": "cls@>=0.1.3 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/cls/-/cls-0.1.5.tgz"
+                    },
+                    "depd": {
+                      "version": "1.0.1",
+                      "from": "depd@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+                    },
+                    "ast-types": {
+                      "version": "0.5.7",
+                      "from": "ast-types@>=0.5.7 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.5.7.tgz"
+                    }
+                  }
+                },
+                "regenerate": {
+                  "version": "1.2.1",
+                  "from": "regenerate@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.4",
+                  "from": "regjsparser@>=0.1.2 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.4.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rsvp": {
+              "version": "3.0.18",
+              "from": "rsvp@>=3.0.13 <4.0.0",
+              "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.18.tgz"
+            },
+            "semver": {
+              "version": "2.3.2",
+              "from": "semver@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "uglify-save-license": {
+      "version": "0.4.1",
+      "from": "uglify-save-license@>=0.4.1 <0.5.0",
+      "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
+    },
+    "webpack": {
+      "version": "1.9.8",
+      "from": "webpack@>=1.4.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.8.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.8.6",
+          "from": "enhanced-resolve@>=0.8.2 <0.9.0",
+          "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.8.6.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.5 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            }
+          }
+        },
+        "esprima": {
+          "version": "1.2.5",
+          "from": "esprima@>=1.2.0 <1.3.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+        },
+        "interpret": {
+          "version": "0.5.2",
+          "from": "interpret@>=0.5.2 <0.6.0",
+          "resolved": "https://registry.npmjs.org/interpret/-/interpret-0.5.2.tgz"
+        },
+        "memory-fs": {
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "1.3.1",
+          "from": "supports-color@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+        },
+        "tapable": {
+          "version": "0.1.9",
+          "from": "tapable@>=0.1.8 <0.2.0",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.1.9.tgz"
+        },
+        "uglify-js": {
+          "version": "2.4.23",
+          "from": "uglify-js@>=2.4.13 <2.5.0",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.4.23.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.34",
+              "from": "source-map@0.1.34",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.34.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.5.4",
+              "from": "yargs@>=3.5.4 <3.6.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.5.4.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.1.0",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
+                },
+                "decamelize": {
+                  "version": "1.0.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                },
+                "wordwrap": {
+                  "version": "0.0.2",
+                  "from": "wordwrap@0.0.2",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.8",
+          "from": "watchpack@>=0.2.1 <0.3.0",
+          "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-0.2.8.tgz",
+          "dependencies": {
+            "chokidar": {
+              "version": "1.0.1",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.1.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.1.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "micromatch": {
+                      "version": "2.1.6",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.1.6.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "1.0.1",
+                          "from": "arr-diff@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-1.0.1.tgz",
+                          "dependencies": {
+                            "array-slice": {
+                              "version": "0.2.3",
+                              "from": "array-slice@>=0.2.2 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz"
+                            }
+                          }
+                        },
+                        "braces": {
+                          "version": "1.8.0",
+                          "from": "braces@>=1.8.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.0.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.1",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.2",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.2.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "1.1.2",
+                                      "from": "is-number@>=1.1.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/is-number/-/is-number-1.1.2.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "1.0.0",
+                                      "from": "isobject@>=1.0.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/isobject/-/isobject-1.0.0.tgz"
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.0",
+                                      "from": "randomatic@>=1.1.0 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.0.tgz"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "debug": {
+                          "version": "2.2.0",
+                          "from": "debug@>=2.1.3 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "0.7.1",
+                              "from": "ms@0.7.1",
+                              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.1",
+                          "from": "expand-brackets@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.1.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.0",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "1.1.0",
+                          "from": "kind-of@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz"
+                        },
+                        "object.omit": {
+                          "version": "0.2.1",
+                          "from": "object.omit@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-0.2.1.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.3",
+                              "from": "for-own@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.3.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "0.1.4",
+                                  "from": "for-in@>=0.1.4 <0.2.0",
+                                  "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.4.tgz"
+                                }
+                              }
+                            },
+                            "isobject": {
+                              "version": "0.2.0",
+                              "from": "isobject@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/isobject/-/isobject-0.2.0.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.2",
+                          "from": "parse-glob@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.2.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.2.0",
+                              "from": "glob-base@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.2.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.0",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.0.tgz"
+                            },
+                            "is-extglob": {
+                              "version": "1.0.0",
+                              "from": "is-extglob@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.2",
+                          "from": "regex-cache@>=0.4.0 <0.5.0",
+                          "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.2.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.2",
+                              "from": "is-equal-shallow@>=0.1.1 <0.2.0",
+                              "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.2.tgz",
+                              "dependencies": {
+                                "is-primitive": {
+                                  "version": "1.0.0",
+                                  "from": "is-primitive@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "arrify": {
+                  "version": "1.0.0",
+                  "from": "arrify@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.0.tgz"
+                },
+                "async-each": {
+                  "version": "0.1.6",
+                  "from": "async-each@>=0.1.5 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz"
+                },
+                "glob-parent": {
+                  "version": "1.2.0",
+                  "from": "glob-parent@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.2.0.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.0",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.0.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.3.1",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.3.1.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "1.1.3",
+                  "from": "is-glob@>=1.1.3 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz"
+                },
+                "readdirp": {
+                  "version": "1.3.0",
+                  "from": "readdirp@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.3.0.tgz",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "2.0.3",
+                      "from": "graceful-fs@>=2.0.0 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+                    },
+                    "minimatch": {
+                      "version": "0.2.14",
+                      "from": "minimatch@>=0.2.12 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.6.4",
+                          "from": "lru-cache@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26-2 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "0.3.6",
+                  "from": "fsevents@>=0.3.1 <0.4.0",
+                  "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.6.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "1.8.4",
+                      "from": "nan@>=1.8.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/nan/-/nan-1.8.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "3.0.7",
+              "from": "graceful-fs@>=3.0.2 <4.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.5",
+          "from": "webpack-core@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/webpack-core/-/webpack-core-0.6.5.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.2",
+              "from": "source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.2.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.5",
+              "from": "source-list-map@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-0.1.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "wiredep": {
+      "version": "2.2.2",
+      "from": "wiredep@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/wiredep/-/wiredep-2.2.2.tgz",
+      "dependencies": {
+        "bower-config": {
+          "version": "0.5.2",
+          "from": "bower-config@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/bower-config/-/bower-config-0.5.2.tgz",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "2.0.3",
+              "from": "graceful-fs@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+            },
+            "mout": {
+              "version": "0.9.1",
+              "from": "mout@>=0.9.0 <0.10.0",
+              "resolved": "https://registry.npmjs.org/mout/-/mout-0.9.1.tgz"
+            },
+            "optimist": {
+              "version": "0.6.1",
+              "from": "optimist@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+              "dependencies": {
+                "wordwrap": {
+                  "version": "0.0.3",
+                  "from": "wordwrap@>=0.0.2 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                },
+                "minimist": {
+                  "version": "0.0.10",
+                  "from": "minimist@>=0.0.1 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.0.3",
+              "from": "osenv@0.0.3",
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.0.3.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "from": "glob@>=4.4.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.8",
+              "from": "minimatch@>=2.0.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.2",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@>=2.4.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+        },
+        "minimist": {
+          "version": "1.1.1",
+          "from": "minimist@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
+        },
+        "propprop": {
+          "version": "0.3.0",
+          "from": "propprop@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/propprop/-/propprop-0.3.0.tgz"
+        },
+        "through2": {
+          "version": "0.6.5",
+          "from": "through2@>=0.6.1 <1.0.0-0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "xtend": {
+              "version": "4.0.0",
+              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "wrench": {
+      "version": "1.5.8",
+      "from": "wrench@>=1.5.8 <1.6.0",
+      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
+    }
+  }
+}

--- a/test/template-tools.js
+++ b/test/template-tools.js
@@ -99,6 +99,7 @@ function deps() {
     };
 
     var string = buffer.toString().replace(/<%[^-].*?%>/g, '');
+    string = string.replace(/"gulp-imagemin".*/, '');
     return ejs.render(string, data);
   }
 


### PR DESCRIPTION
* use cache directories for `node_modules` and `test/tmp/deps/node_modules`
* add script folder to manage cache and test workflow (with npm-shrinkwrap)
* catch coverage data during build, if success send to Coveralls.io (avoid second build only for coverall)
* update LoDash and clean package.json
* use local mocha, istanbul
* ignore "gulp-imagemin" for testing

***

The cached directory `test/tmp/deps/node_modules` doesn't contain deps `tsd` due a extraneous deps who block npm-shrinkwrap https://github.com/DefinitelyTyped/tsd/issues/156