### PR TITLE
Update gulp version to 3.9.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -6,7 +6,7 @@
     "test": "gulp test"
   },
   "devDependencies": {
-    "gulp": "~3.8.10",
+    "gulp": "~3.9.0",
     "gulp-autoprefixer": "~2.1.0",
     "gulp-angular-templatecache": "~1.5.0",
     "del": "~1.1.1",


### PR DESCRIPTION
Gulp is now installed in version 3.9 by default, and I get red warning message when running it on my app.
I upgraded to version 3.9 and i didn't notice any problem.