### PR TITLE
New angular-bootstrap release

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -39,7 +39,7 @@
 <% } if(props.ui.key === 'angular-material') { -%>
     "angular-material": "~0.8.3",
 <% } if(props.bootstrapComponents.key === 'ui-bootstrap') { -%>
-    "angular-bootstrap": "~0.12.0",
+    "angular-bootstrap": "~0.13.0",
 <% } if(props.bootstrapComponents.key === 'angular-strap') { -%>
     "angular-strap": "~2.1.6",
 <% } if(props.foundationComponents.key === 'angular-foundation') { -%>


### PR DESCRIPTION
Angular-bootstrap has released  version 0.13.0 which is compatible with angular '<=1.3.x'.

Resolves this confusion in bower:

```
Please note that,
    angular-bootstrap#0.12.1 depends on angular#>=1 <1.3.0 which resolved to angular#1.2.28
    angular-animate#1.3.15, angular-cookies#1.3.15, angular-mocks#1.3.15, angular-resource#1.3.15, angular-sanitize#1.3.15, angular-touch#1.3.15 depends on angular#1.3.15 which resolved to angular#1.3.15
    kornerKase depends on angular#~1.3.4 which resolved to angular#1.3.15
    angular-ui-router#0.2.15 depends on angular#>= 1.0.8 which resolved to angular#1.3.15
Resort to using angular#~1.3.4 which resolved to angular#1.3.15
Code incompatibilities may occur.

bower angular-bootstrap#~0.12.0               install angular-bootstrap#0.12.1
```