### PR TITLE
Ignore empty folder in dist folder

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -100,10 +100,15 @@ gulp.task('fonts', function () {
 });
 
 gulp.task('other', function () {
+  var fileFilter = $.filter(function (file) {
+    return file.stat.isFile();
+  });
+
   return gulp.src([
     path.join(conf.paths.src, '/**/*'),
     path.join('!' + conf.paths.src, '/**/*.{<%- processedFileExtension %>}')
   ])
+    .pipe(fileFilter)
     .pipe(gulp.dest(path.join(conf.paths.dist, '/')));
 });
 


### PR DESCRIPTION
Fix #502

Use a `gulp-filter` to ignore empty folder in dist folder.