### PR TITLE
fix stylus relative path

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -33,7 +33,7 @@ gulp.task('styles', function () {
 
   var injectOptions = {
     transform: function(filePath) {
-      filePath = filePath.replace(path.join(conf.paths.src, '/app/'), '');
+      filePath = path.relative(path.join(conf.paths.src, '/app/'), filePath);
       return '@import \'' + filePath + '\';';
     },
     starttag: '// injector',


### PR DESCRIPTION
fix #569 
On Windows, path produces backslash instead of forward slash. Using path.relative should be safe across systems