### PR TITLE
Remove gulp jscs

### DIFF
--- a/app/src/preprocessors.js
+++ b/app/src/preprocessors.js
@@ -77,14 +77,6 @@ module.exports = function(GulpAngularGenerator) {
    * Copy additional lint files if needed
    */
   GulpAngularGenerator.prototype.lintCopies = function lintCopies() {
-    if(this.props.jsPreprocessor.key === 'none') {
-      this.files.push({
-        src: '.jscsrc',
-        dest: '.jscsrc',
-        template: false
-      });
-    }
-
     if(this.props.jsPreprocessor.key === 'coffee') {
       this.files.push({
         src: 'coffeelint.json',

--- a/app/templates/.jscsrc
+++ b/app/templates/.jscsrc
@@ -1,4 +1,0 @@
-{
-  "preset": "google",
-  "maximumLineLength": null
-}

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -17,7 +17,6 @@
 <% if (imageMin) { -%>
     "gulp-imagemin": "~2.2.0",
 <% } -%>
-    "gulp-jscs": "~1.6.0",
     "gulp-jshint": "~1.11.0",
     "gulp-load-plugins": "~0.10.0",
     "gulp-size": "~1.2.1",

--- a/app/templates/gulp/_scripts.js
+++ b/app/templates/gulp/_scripts.js
@@ -23,10 +23,6 @@ gulp.task('scripts', function () {
 <%   if (props.jsPreprocessor.extension === 'js') { -%>
     .pipe($.jshint())
     .pipe($.jshint.reporter('jshint-stylish'))
-    .pipe($.jscs({
-      fix: true,
-      configPath: '.jscsrc'
-    }))
 <%   } if (props.jsPreprocessor.key !== 'none') { -%>
     .pipe($.sourcemaps.init())
 <%   } if (props.jsPreprocessor.key === 'coffee') { -%>
@@ -44,9 +40,6 @@ gulp.task('scripts', function () {
 <%   } -%>
     .pipe(browserSync.reload({ stream: true }))
     .pipe($.size())
-<%   if (props.jsPreprocessor.key === 'none') { -%>
-    .pipe(gulp.dest(path.join(conf.paths.src, '/app/')));
-<%   } -%>
 });
 <% } else { -%>
 function webpack(watch, callback) {

--- a/test/node/test-preprocessors.js
+++ b/test/node/test-preprocessors.js
@@ -94,14 +94,6 @@ describe('gulp-angular generator preprocessors script', function () {
   });
 
   describe('add lint configuration files for preprocessors different from es6', function() {
-    it('should add .jscsrc for none preprocessor', function() {
-      generator.props = {
-        jsPreprocessor: { key: 'none' }
-      };
-      generator.lintCopies();
-      generator.files[6].src.should.match(/jscsrc/);
-    });
-
     it('should add coffeelint for coffee preprocessor', function() {
       generator.props = {
         jsPreprocessor: { key: 'coffee' }

--- a/test/npm-shrinkwrap.json
+++ b/test/npm-shrinkwrap.json
@@ -3,14 +3,14 @@
   "version": "0.0.0",
   "dependencies": {
     "babel-core": {
-      "version": "5.5.6",
+      "version": "5.5.8",
       "from": "babel-core@>=5.5.4 <5.6.0",
-      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.5.6.tgz",
+      "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.5.8.tgz",
       "dependencies": {
         "acorn-jsx": {
-          "version": "1.0.2",
+          "version": "1.0.3",
           "from": "acorn-jsx@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-1.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-1.0.3.tgz",
           "dependencies": {
             "acorn": {
               "version": "1.2.2",
@@ -25,9 +25,9 @@
           "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.6.tgz"
         },
         "bluebird": {
-          "version": "2.9.27",
+          "version": "2.9.30",
           "from": "bluebird@>=2.9.25 <3.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
         },
         "convert-source-map": {
           "version": "1.1.1",
@@ -35,9 +35,9 @@
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
         },
         "core-js": {
-          "version": "0.9.15",
+          "version": "0.9.18",
           "from": "core-js@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.15.tgz"
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-0.9.18.tgz"
         },
         "debug": {
           "version": "2.2.0",
@@ -434,13 +434,13 @@
           }
         },
         "regexpu": {
-          "version": "1.1.2",
+          "version": "1.2.0",
           "from": "regexpu@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.2.0.tgz",
           "dependencies": {
             "recast": {
               "version": "0.10.12",
-              "from": "recast@>=0.10.1 <0.11.0",
+              "from": "recast@>=0.10.6 <0.11.0",
               "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.12.tgz",
               "dependencies": {
                 "esprima-fb": {
@@ -567,14 +567,14 @@
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
         },
         "loader-utils": {
-          "version": "0.2.9",
+          "version": "0.2.10",
           "from": "loader-utils@>=0.2.7 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.0.2",
+              "version": "3.1.3",
               "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
@@ -586,9 +586,9 @@
       }
     },
     "browser-sync": {
-      "version": "2.7.7",
+      "version": "2.7.12",
       "from": "browser-sync@>=2.7.6 <2.8.0",
-      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.7.7.tgz",
+      "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.7.12.tgz",
       "dependencies": {
         "anymatch": {
           "version": "1.3.0",
@@ -787,34 +787,46 @@
           "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz"
         },
         "browser-sync-client": {
-          "version": "2.0.2",
-          "from": "browser-sync-client@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.0.2.tgz"
+          "version": "2.2.1",
+          "from": "browser-sync-client@>=2.2.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.2.1.tgz",
+          "dependencies": {
+            "etag": {
+              "version": "1.7.0",
+              "from": "etag@>=1.7.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
+            },
+            "fresh": {
+              "version": "0.3.0",
+              "from": "fresh@>=0.3.0 <0.4.0",
+              "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+            }
+          }
         },
         "browser-sync-ui": {
           "version": "0.5.9",
-          "from": "browser-sync-ui@>=0.5.8 <0.6.0",
+          "from": "browser-sync-ui@>=0.5.9 <0.6.0",
           "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-0.5.9.tgz",
           "dependencies": {
             "angular": {
-              "version": "1.3.16",
+              "version": "1.4.1",
               "from": "angular@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular/-/angular-1.3.16.tgz"
+              "resolved": "https://registry.npmjs.org/angular/-/angular-1.4.1.tgz"
             },
             "angular-route": {
-              "version": "1.3.16",
+              "version": "1.4.1",
               "from": "angular-route@>=1.3.8 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.3.16.tgz"
+              "resolved": "https://registry.npmjs.org/angular-route/-/angular-route-1.4.1.tgz"
             },
             "angular-sanitize": {
-              "version": "1.3.16",
+              "version": "1.4.1",
               "from": "angular-sanitize@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.3.16.tgz"
+              "resolved": "https://registry.npmjs.org/angular-sanitize/-/angular-sanitize-1.4.1.tgz"
             },
             "angular-touch": {
-              "version": "1.3.16",
+              "version": "1.4.1",
               "from": "angular-touch@>=1.3.11 <2.0.0",
-              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.3.16.tgz"
+              "resolved": "https://registry.npmjs.org/angular-touch/-/angular-touch-1.4.1.tgz"
             },
             "connect-history-api-fallback": {
               "version": "0.0.5",
@@ -907,7 +919,7 @@
         },
         "chokidar": {
           "version": "1.0.3",
-          "from": "chokidar@>=1.0.1 <2.0.0",
+          "from": "chokidar@>=1.0.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.3.tgz",
           "dependencies": {
             "arrify": {
@@ -1136,7 +1148,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1148,7 +1160,7 @@
                       "dependencies": {
                         "ansi-regex": {
                           "version": "0.2.1",
-                          "from": "ansi-regex@>=0.2.0 <0.3.0",
+                          "from": "ansi-regex@>=0.2.1 <0.3.0",
                           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                         }
                       }
@@ -1175,13 +1187,13 @@
           "resolved": "https://registry.npmjs.org/emitter-steward/-/emitter-steward-0.0.1.tgz"
         },
         "foxy": {
-          "version": "11.0.0",
-          "from": "foxy@>=11.0.0 <12.0.0",
-          "resolved": "https://registry.npmjs.org/foxy/-/foxy-11.0.0.tgz",
+          "version": "11.0.3",
+          "from": "foxy@>=11.0.2 <12.0.0",
+          "resolved": "https://registry.npmjs.org/foxy/-/foxy-11.0.3.tgz",
           "dependencies": {
             "cookie": {
               "version": "0.1.3",
-              "from": "cookie@>=0.1.2 <0.2.0",
+              "from": "cookie@>=0.1.3 <0.2.0",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
             },
             "http-proxy": {
@@ -1190,9 +1202,9 @@
               "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
               "dependencies": {
                 "eventemitter3": {
-                  "version": "1.1.0",
+                  "version": "1.1.1",
                   "from": "eventemitter3@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
                 },
                 "requires-port": {
                   "version": "0.0.1",
@@ -1203,7 +1215,7 @@
             },
             "lodash.merge": {
               "version": "3.3.1",
-              "from": "lodash.merge@>=3.3.0 <4.0.0",
+              "from": "lodash.merge@>=3.3.1 <4.0.0",
               "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-3.3.1.tgz",
               "dependencies": {
                 "lodash._arraycopy": {
@@ -1297,13 +1309,13 @@
           }
         },
         "immutable": {
-          "version": "3.7.3",
-          "from": "immutable@>=3.6.4 <4.0.0",
-          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.3.tgz"
+          "version": "3.7.4",
+          "from": "immutable@>=3.7.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.4.tgz"
         },
         "localtunnel": {
           "version": "1.5.1",
-          "from": "localtunnel@>=1.3.0 <2.0.0",
+          "from": "localtunnel@>=1.5.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.5.1.tgz",
           "dependencies": {
             "request": {
@@ -1427,9 +1439,9 @@
           }
         },
         "opn": {
-          "version": "1.0.2",
-          "from": "opn@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
+          "version": "2.0.0",
+          "from": "opn@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-2.0.0.tgz"
         },
         "pad-left": {
           "version": "1.0.2",
@@ -1457,13 +1469,13 @@
         },
         "query-string": {
           "version": "2.3.0",
-          "from": "query-string@>=2.0.0 <3.0.0",
+          "from": "query-string@>=2.3.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-2.3.0.tgz"
         },
         "resp-modifier": {
-          "version": "3.1.2",
-          "from": "resp-modifier@>=3.1.2 <4.0.0",
-          "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-3.1.2.tgz",
+          "version": "4.0.2",
+          "from": "resp-modifier@>=4.0.2 <5.0.0",
+          "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-4.0.2.tgz",
           "dependencies": {
             "minimatch": {
               "version": "2.0.8",
@@ -1492,27 +1504,15 @@
           }
         },
         "serve-index": {
-          "version": "1.6.4",
-          "from": "serve-index@>=1.6.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.6.4.tgz",
+          "version": "1.7.0",
+          "from": "serve-index@>=1.7.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.0.tgz",
           "dependencies": {
             "accepts": {
               "version": "1.2.9",
-              "from": "accepts@>=1.2.7 <1.3.0",
+              "from": "accepts@>=1.2.9 <1.3.0",
               "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.9.tgz",
               "dependencies": {
-                "mime-types": {
-                  "version": "2.1.1",
-                  "from": "mime-types@>=2.1.1 <2.2.0",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.13.0",
-                      "from": "mime-db@>=1.13.0 <1.14.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
-                    }
-                  }
-                },
                 "negotiator": {
                   "version": "0.5.3",
                   "from": "negotiator@0.5.3",
@@ -1538,9 +1538,9 @@
               }
             },
             "escape-html": {
-              "version": "1.0.1",
-              "from": "escape-html@1.0.1",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "escape-html@1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
             },
             "http-errors": {
               "version": "1.3.1",
@@ -1554,20 +1554,20 @@
                 },
                 "statuses": {
                   "version": "1.2.1",
-                  "from": "statuses@>=1.2.1 <2.0.0",
+                  "from": "statuses@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
             },
             "mime-types": {
-              "version": "2.0.14",
-              "from": "mime-types@>=2.0.11 <2.1.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+              "version": "2.1.1",
+              "from": "mime-types@>=2.1.1 <2.2.0",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
               "dependencies": {
                 "mime-db": {
-                  "version": "1.12.0",
-                  "from": "mime-db@>=1.12.0 <1.13.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                  "version": "1.13.0",
+                  "from": "mime-db@>=1.13.0 <1.14.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                 }
               }
             },
@@ -1579,14 +1579,14 @@
           }
         },
         "serve-static": {
-          "version": "1.9.3",
-          "from": "serve-static@>=1.9.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.9.3.tgz",
+          "version": "1.10.0",
+          "from": "serve-static@>=1.9.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
           "dependencies": {
             "escape-html": {
-              "version": "1.0.1",
-              "from": "escape-html@1.0.1",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "escape-html@1.0.2",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
             },
             "parseurl": {
               "version": "1.3.0",
@@ -1594,9 +1594,9 @@
               "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
             },
             "send": {
-              "version": "0.12.3",
-              "from": "send@0.12.3",
-              "resolved": "https://registry.npmjs.org/send/-/send-0.12.3.tgz",
+              "version": "0.13.0",
+              "from": "send@0.13.0",
+              "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
               "dependencies": {
                 "debug": {
                   "version": "2.2.0",
@@ -1614,21 +1614,26 @@
                   "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
                 },
                 "etag": {
-                  "version": "1.6.0",
-                  "from": "etag@>=1.6.0 <1.7.0",
-                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.6.0.tgz",
-                  "dependencies": {
-                    "crc": {
-                      "version": "3.2.1",
-                      "from": "crc@3.2.1",
-                      "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
-                    }
-                  }
+                  "version": "1.7.0",
+                  "from": "etag@>=1.7.0 <1.8.0",
+                  "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "fresh": {
-                  "version": "0.2.4",
-                  "from": "fresh@0.2.4",
-                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+                  "version": "0.3.0",
+                  "from": "fresh@0.3.0",
+                  "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz"
+                },
+                "http-errors": {
+                  "version": "1.3.1",
+                  "from": "http-errors@>=1.3.1 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    }
+                  }
                 },
                 "mime": {
                   "version": "1.3.4",
@@ -1641,14 +1646,14 @@
                   "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
                 },
                 "on-finished": {
-                  "version": "2.2.1",
-                  "from": "on-finished@>=2.2.1 <2.3.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
                   "dependencies": {
                     "ee-first": {
-                      "version": "1.1.0",
-                      "from": "ee-first@1.1.0",
-                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
                     }
                   }
                 },
@@ -1656,13 +1661,13 @@
                   "version": "1.0.2",
                   "from": "range-parser@>=1.0.2 <1.1.0",
                   "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@>=1.2.1 <1.3.0",
+                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
                 }
               }
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
-              "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
             }
           }
         },
@@ -1704,9 +1709,9 @@
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "ultron@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     }
                   }
                 },
@@ -2180,7 +2185,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             },
             "get-stdin": {
@@ -2197,7 +2202,7 @@
           "dependencies": {
             "ansi-regex": {
               "version": "1.1.1",
-              "from": "ansi-regex@>=1.0.0 <2.0.0",
+              "from": "ansi-regex@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
             }
           }
@@ -2210,9 +2215,9 @@
       }
     },
     "concat-stream": {
-      "version": "1.4.8",
+      "version": "1.4.10",
       "from": "concat-stream@>=1.4.8 <1.5.0",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.8.tgz",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz",
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -2623,21 +2628,21 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
         },
         "tildify": {
-          "version": "1.0.0",
+          "version": "1.1.0",
           "from": "tildify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.1.0.tgz",
           "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
+            "os-homedir": {
+              "version": "1.0.0",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.0.tgz"
             }
           }
         },
         "v8flags": {
-          "version": "2.0.5",
+          "version": "2.0.7",
           "from": "v8flags@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.0.7.tgz",
           "dependencies": {
             "user-home": {
               "version": "1.1.1",
@@ -2897,7 +2902,7 @@
                 },
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "from": "clone-stats@>=0.0.1 <0.0.2",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -3115,19 +3120,29 @@
               "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
             },
             "through2": {
-              "version": "0.6.5",
+              "version": "2.0.0",
               "from": "through2@*",
-              "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+              "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                  "version": "2.0.0",
+                  "from": "readable-stream@>=2.0.0 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.1",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -3139,16 +3154,16 @@
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "4.0.0",
-                  "from": "xtend@>=4.0.0 <4.1.0-0",
+                  "from": "xtend@>=4.0.0 <4.1.0",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                 }
               }
@@ -3178,9 +3193,9 @@
               "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.1.0.tgz"
             },
             "caniuse-db": {
-              "version": "1.0.30000208",
+              "version": "1.0.30000212",
               "from": "caniuse-db@>=1.0.30000181 <2.0.0",
-              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000208.tgz"
+              "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000212.tgz"
             }
           }
         },
@@ -3220,7 +3235,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -3259,7 +3274,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.3 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -3327,7 +3342,7 @@
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -3546,7 +3561,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -3703,7 +3718,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -3832,462 +3847,6 @@
               "version": "0.0.4",
               "from": "stream-combiner@>=0.0.4 <0.1.0",
               "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz"
-            }
-          }
-        }
-      }
-    },
-    "gulp-jscs": {
-      "version": "1.6.0",
-      "from": "gulp-jscs@>=1.6.0 <1.7.0",
-      "resolved": "https://registry.npmjs.org/gulp-jscs/-/gulp-jscs-1.6.0.tgz",
-      "dependencies": {
-        "jscs": {
-          "version": "1.13.1",
-          "from": "jscs@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jscs/-/jscs-1.13.1.tgz",
-          "dependencies": {
-            "cli-table": {
-              "version": "0.3.1",
-              "from": "cli-table@>=0.3.1 <0.4.0",
-              "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
-              "dependencies": {
-                "colors": {
-                  "version": "1.0.3",
-                  "from": "colors@1.0.3",
-                  "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
-                }
-              }
-            },
-            "commander": {
-              "version": "2.6.0",
-              "from": "commander@>=2.6.0 <2.7.0",
-              "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
-            },
-            "esprima": {
-              "version": "1.2.5",
-              "from": "esprima@>=1.2.5 <2.0.0",
-              "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
-            },
-            "esprima-harmony-jscs": {
-              "version": "1.1.0-bin",
-              "from": "esprima-harmony-jscs@1.1.0-bin",
-              "resolved": "https://registry.npmjs.org/esprima-harmony-jscs/-/esprima-harmony-jscs-1.1.0-bin.tgz"
-            },
-            "estraverse": {
-              "version": "1.9.3",
-              "from": "estraverse@>=1.9.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-            },
-            "exit": {
-              "version": "0.1.2",
-              "from": "exit@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
-            },
-            "glob": {
-              "version": "5.0.10",
-              "from": "glob@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
-              "dependencies": {
-                "inflight": {
-                  "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                },
-                "once": {
-                  "version": "1.3.2",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.0",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
-                }
-              }
-            },
-            "lodash.assign": {
-              "version": "3.0.0",
-              "from": "lodash.assign@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.0.0.tgz",
-              "dependencies": {
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    },
-                    "lodash.keys": {
-                      "version": "3.1.1",
-                      "from": "lodash.keys@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
-                      "dependencies": {
-                        "lodash._getnative": {
-                          "version": "3.9.0",
-                          "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
-                        },
-                        "lodash.isarguments": {
-                          "version": "3.0.3",
-                          "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
-                        },
-                        "lodash.isarray": {
-                          "version": "3.0.3",
-                          "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    },
-                    "lodash.restparam": {
-                      "version": "3.6.1",
-                      "from": "lodash.restparam@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "minimatch": {
-              "version": "2.0.8",
-              "from": "minimatch@>=2.0.1 <2.1.0",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.0",
-                  "from": "brace-expansion@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.0",
-                      "from": "balanced-match@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "pathval": {
-              "version": "0.1.1",
-              "from": "pathval@>=0.1.1 <0.2.0",
-              "resolved": "https://registry.npmjs.org/pathval/-/pathval-0.1.1.tgz"
-            },
-            "prompt": {
-              "version": "0.2.14",
-              "from": "prompt@>=0.2.14 <0.3.0",
-              "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
-              "dependencies": {
-                "pkginfo": {
-                  "version": "0.3.0",
-                  "from": "pkginfo@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
-                },
-                "read": {
-                  "version": "1.0.6",
-                  "from": "read@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/read/-/read-1.0.6.tgz",
-                  "dependencies": {
-                    "mute-stream": {
-                      "version": "0.0.5",
-                      "from": "mute-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                    }
-                  }
-                },
-                "revalidator": {
-                  "version": "0.1.8",
-                  "from": "revalidator@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz"
-                },
-                "utile": {
-                  "version": "0.2.1",
-                  "from": "utile@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.9 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                    },
-                    "deep-equal": {
-                      "version": "1.0.0",
-                      "from": "deep-equal@*",
-                      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.0.tgz"
-                    },
-                    "i": {
-                      "version": "0.3.3",
-                      "from": "i@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/i/-/i-0.3.3.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.0.0 <1.0.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "ncp": {
-                      "version": "0.4.2",
-                      "from": "ncp@>=0.4.0 <0.5.0",
-                      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.4.0",
-                      "from": "rimraf@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.0.tgz",
-                      "dependencies": {
-                        "glob": {
-                          "version": "4.5.3",
-                          "from": "glob@>=4.4.2 <5.0.0",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                          "dependencies": {
-                            "inflight": {
-                              "version": "1.0.4",
-                              "from": "inflight@>=1.0.4 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                            },
-                            "once": {
-                              "version": "1.3.2",
-                              "from": "once@>=1.3.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                              "dependencies": {
-                                "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "winston": {
-                  "version": "0.8.3",
-                  "from": "winston@>=0.8.0 <0.9.0",
-                  "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
-                  "dependencies": {
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-                    },
-                    "colors": {
-                      "version": "0.6.2",
-                      "from": "colors@>=0.6.0 <0.7.0",
-                      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
-                    },
-                    "cycle": {
-                      "version": "1.0.3",
-                      "from": "cycle@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
-                    },
-                    "eyes": {
-                      "version": "0.1.8",
-                      "from": "eyes@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "stack-trace": {
-                      "version": "0.0.9",
-                      "from": "stack-trace@>=0.0.0 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-json-comments": {
-              "version": "1.0.2",
-              "from": "strip-json-comments@>=1.0.2 <1.1.0",
-              "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.2.tgz"
-            },
-            "vow": {
-              "version": "0.4.9",
-              "from": "vow@>=0.4.8 <0.5.0",
-              "resolved": "https://registry.npmjs.org/vow/-/vow-0.4.9.tgz"
-            },
-            "vow-fs": {
-              "version": "0.3.4",
-              "from": "vow-fs@>=0.3.4 <0.4.0",
-              "resolved": "https://registry.npmjs.org/vow-fs/-/vow-fs-0.3.4.tgz",
-              "dependencies": {
-                "node-uuid": {
-                  "version": "1.4.3",
-                  "from": "node-uuid@>=1.4.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                },
-                "vow-queue": {
-                  "version": "0.4.2",
-                  "from": "vow-queue@>=0.4.1 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/vow-queue/-/vow-queue-0.4.2.tgz"
-                },
-                "glob": {
-                  "version": "4.5.3",
-                  "from": "glob@>=4.3.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
-                  "dependencies": {
-                    "inflight": {
-                      "version": "1.0.4",
-                      "from": "inflight@>=1.0.4 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@>=1.3.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "xmlbuilder": {
-              "version": "2.6.4",
-              "from": "xmlbuilder@>=2.6.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.4.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "2.1.1",
-          "from": "object-assign@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
-        },
-        "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-          "dependencies": {
-            "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
-                },
-                "isarray": {
-                  "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "xtend": {
-              "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
-            }
-          }
-        },
-        "tildify": {
-          "version": "1.0.0",
-          "from": "tildify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/tildify/-/tildify-1.0.0.tgz",
-          "dependencies": {
-            "user-home": {
-              "version": "1.1.1",
-              "from": "user-home@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
             }
           }
         }
@@ -4750,9 +4309,9 @@
               }
             },
             "request": {
-              "version": "2.57.0",
+              "version": "2.58.0",
               "from": "request@>=2.51.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
@@ -4793,30 +4352,35 @@
                   "from": "caseless@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
+                "extend": {
+                  "version": "2.0.1",
+                  "from": "extend@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "version": "1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                      "version": "1.2.1",
+                      "from": "async@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
                     },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "mime-types": {
+                      "version": "2.1.1",
+                      "from": "mime-types@>=2.1.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                       "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        "mime-db": {
+                          "version": "1.13.0",
+                          "from": "mime-db@>=1.13.0 <1.14.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                         }
                       }
                     }
@@ -4855,9 +4419,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.2.0",
+                  "version": "2.0.0",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.11.0",
@@ -4897,9 +4461,9 @@
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
-                      "version": "2.7.2",
+                      "version": "2.8.0",
                       "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
@@ -4924,13 +4488,13 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
-                  "version": "1.0.3",
+                  "version": "1.0.5",
                   "from": "combined-stream@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <2.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
@@ -4946,9 +4510,9 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.27",
+                      "version": "2.9.30",
                       "from": "bluebird@>=2.9.26 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
@@ -5021,7 +4585,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -5060,7 +4624,7 @@
         },
         "vinyl-sourcemaps-apply": {
           "version": "0.1.4",
-          "from": "vinyl-sourcemaps-apply@>=0.1.3 <0.2.0",
+          "from": "vinyl-sourcemaps-apply@>=0.1.4 <0.2.0",
           "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.1.4.tgz",
           "dependencies": {
             "source-map": {
@@ -5539,7 +5103,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -5551,7 +5115,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -5778,7 +5342,7 @@
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -6098,9 +5662,9 @@
                   "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.2.0",
+                  "version": "2.0.0",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "form-data": {
                   "version": "0.1.4",
@@ -6275,9 +5839,9 @@
                       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
                     },
                     "ultron": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "ultron@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
                     },
                     "bufferutil": {
                       "version": "1.1.0",
@@ -6363,7 +5927,7 @@
               "dependencies": {
                 "exit": {
                   "version": "0.1.2",
-                  "from": "exit@>=0.1.0 <0.2.0",
+                  "from": "exit@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz"
                 },
                 "jasmine-core": {
@@ -6581,7 +6145,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -6667,9 +6231,9 @@
       }
     },
     "gulp-rev-replace": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "from": "gulp-rev-replace@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/gulp-rev-replace/-/gulp-rev-replace-0.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-rev-replace/-/gulp-rev-replace-0.4.2.tgz",
       "dependencies": {
         "event-stream": {
           "version": "3.3.1",
@@ -6740,7 +6304,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -6752,7 +6316,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "ansi-regex@>=0.2.0 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -6979,7 +6543,7 @@
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -7116,7 +6680,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7128,7 +6692,7 @@
               "dependencies": {
                 "ansi-regex": {
                   "version": "0.2.1",
-                  "from": "ansi-regex@>=0.2.0 <0.3.0",
+                  "from": "ansi-regex@>=0.2.1 <0.3.0",
                   "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                 }
               }
@@ -7410,7 +6974,7 @@
                   "dependencies": {
                     "duplexer2": {
                       "version": "0.0.2",
-                      "from": "duplexer2@>=0.0.2 <0.1.0",
+                      "from": "duplexer2@0.0.2",
                       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                       "dependencies": {
                         "readable-stream": {
@@ -7539,9 +7103,9 @@
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.0.1.tgz",
       "dependencies": {
         "node-sass": {
-          "version": "3.1.2",
+          "version": "3.2.0",
           "from": "node-sass@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.2.0.tgz",
           "dependencies": {
             "async-foreach": {
               "version": "0.1.3",
@@ -7795,9 +7359,16 @@
                   }
                 },
                 "osenv": {
-                  "version": "0.1.1",
+                  "version": "0.1.2",
                   "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
                 },
                 "semver": {
                   "version": "4.3.6",
@@ -7969,9 +7540,16 @@
                   }
                 },
                 "osenv": {
-                  "version": "0.1.1",
+                  "version": "0.1.2",
                   "from": "osenv@>=0.0.0 <1.0.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
                 },
                 "request": {
                   "version": "2.51.0",
@@ -8072,9 +7650,9 @@
                       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                     },
                     "tough-cookie": {
-                      "version": "1.2.0",
+                      "version": "2.0.0",
                       "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                     },
                     "http-signature": {
                       "version": "0.10.1",
@@ -8189,9 +7767,9 @@
               }
             },
             "request": {
-              "version": "2.57.0",
+              "version": "2.58.0",
               "from": "request@>=2.55.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
               "dependencies": {
                 "bl": {
                   "version": "0.9.4",
@@ -8232,30 +7810,35 @@
                   "from": "caseless@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
                 },
+                "extend": {
+                  "version": "2.0.1",
+                  "from": "extend@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+                },
                 "forever-agent": {
                   "version": "0.6.1",
                   "from": "forever-agent@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
                 },
                 "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "version": "1.0.0-rc1",
+                  "from": "form-data@>=1.0.0-rc1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
                   "dependencies": {
                     "async": {
-                      "version": "0.9.2",
-                      "from": "async@>=0.9.0 <0.10.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                      "version": "1.2.1",
+                      "from": "async@>=1.2.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
                     },
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "combined-stream@>=0.0.4 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "mime-types": {
+                      "version": "2.1.1",
+                      "from": "mime-types@>=2.1.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                       "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        "mime-db": {
+                          "version": "1.13.0",
+                          "from": "mime-db@>=1.13.0 <1.14.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                         }
                       }
                     }
@@ -8294,9 +7877,9 @@
                   "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
                 },
                 "tough-cookie": {
-                  "version": "1.2.0",
+                  "version": "2.0.0",
                   "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
                 },
                 "http-signature": {
                   "version": "0.11.0",
@@ -8336,9 +7919,9 @@
                       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                     },
                     "boom": {
-                      "version": "2.7.2",
+                      "version": "2.8.0",
                       "from": "boom@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                     },
                     "cryptiles": {
                       "version": "2.0.4",
@@ -8363,13 +7946,13 @@
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
                 },
                 "combined-stream": {
-                  "version": "1.0.3",
+                  "version": "1.0.5",
                   "from": "combined-stream@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
                   "dependencies": {
                     "delayed-stream": {
                       "version": "1.0.0",
-                      "from": "delayed-stream@>=1.0.0 <2.0.0",
+                      "from": "delayed-stream@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                     }
                   }
@@ -8385,9 +7968,9 @@
                   "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
                   "dependencies": {
                     "bluebird": {
-                      "version": "2.9.27",
+                      "version": "2.9.30",
                       "from": "bluebird@>=2.9.26 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                     },
                     "commander": {
                       "version": "2.8.1",
@@ -8445,9 +8028,9 @@
               "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.0.0.tgz",
               "dependencies": {
                 "yargs": {
-                  "version": "3.10.0",
+                  "version": "3.11.0",
                   "from": "yargs@>=3.8.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                  "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.11.0.tgz",
                   "dependencies": {
                     "camelcase": {
                       "version": "1.1.0",
@@ -8466,7 +8049,7 @@
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
@@ -8495,7 +8078,7 @@
                           "dependencies": {
                             "align-text": {
                               "version": "0.1.3",
-                              "from": "align-text@>=0.1.0 <0.2.0",
+                              "from": "align-text@>=0.1.1 <0.2.0",
                               "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
                               "dependencies": {
                                 "kind-of": {
@@ -8530,9 +8113,9 @@
                       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.0.0.tgz"
                     },
                     "window-size": {
-                      "version": "0.1.0",
-                      "from": "window-size@0.1.0",
-                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                      "version": "0.1.1",
+                      "from": "window-size@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.1.tgz"
                     }
                   }
                 }
@@ -8552,7 +8135,7 @@
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.17 <1.1.0",
+              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
@@ -8703,7 +8286,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -8776,7 +8359,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -8833,23 +8416,23 @@
       }
     },
     "gulp-stylus": {
-      "version": "2.0.3",
+      "version": "2.0.5",
       "from": "gulp-stylus@>=2.0.3 <2.1.0",
-      "resolved": "https://registry.npmjs.org/gulp-stylus/-/gulp-stylus-2.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-stylus/-/gulp-stylus-2.0.5.tgz",
       "dependencies": {
         "accord": {
-          "version": "0.15.2",
-          "from": "accord@>=0.15.2 <0.16.0",
-          "resolved": "https://registry.npmjs.org/accord/-/accord-0.15.2.tgz",
+          "version": "0.19.0",
+          "from": "accord@>=0.19.0 <0.20.0",
+          "resolved": "https://registry.npmjs.org/accord/-/accord-0.19.0.tgz",
           "dependencies": {
             "convert-source-map": {
-              "version": "0.4.1",
-              "from": "convert-source-map@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.4.1.tgz"
+              "version": "1.1.1",
+              "from": "convert-source-map@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
             },
             "fobject": {
               "version": "0.0.3",
-              "from": "fobject@>=0.0.0 <1.0.0",
+              "from": "fobject@0.0.3",
               "resolved": "https://registry.npmjs.org/fobject/-/fobject-0.0.3.tgz",
               "dependencies": {
                 "graceful-fs": {
@@ -8865,9 +8448,9 @@
               }
             },
             "glob": {
-              "version": "4.5.3",
-              "from": "glob@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "version": "5.0.10",
+              "from": "glob@>=5.0.0 <6.0.0",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.10.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
@@ -8888,7 +8471,7 @@
                 },
                 "minimatch": {
                   "version": "2.0.8",
-                  "from": "minimatch@>=2.0.7 <3.0.0",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
@@ -8921,6 +8504,11 @@
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.0",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
                 }
               }
             },
@@ -8941,7 +8529,7 @@
               "dependencies": {
                 "async": {
                   "version": "0.2.10",
-                  "from": "async@>=0.2.6 <0.3.0",
+                  "from": "async@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
                 },
                 "source-map": {
@@ -8994,6 +8582,69 @@
               "version": "3.7.3",
               "from": "when@>=3.0.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/when/-/when-3.7.3.tgz"
+            }
+          }
+        },
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@>=3.2.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                }
+              }
+            },
+            "lodash._createassigner": {
+              "version": "3.1.1",
+              "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+              "dependencies": {
+                "lodash._bindcallback": {
+                  "version": "3.0.1",
+                  "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                },
+                "lodash._isiterateecall": {
+                  "version": "3.0.9",
+                  "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                },
+                "lodash.restparam": {
+                  "version": "3.6.1",
+                  "from": "lodash.restparam@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+                }
+              }
+            },
+            "lodash.keys": {
+              "version": "3.1.1",
+              "from": "lodash.keys@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.1.tgz",
+              "dependencies": {
+                "lodash._getnative": {
+                  "version": "3.9.0",
+                  "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.0.tgz"
+                },
+                "lodash.isarguments": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.0.3.tgz"
+                },
+                "lodash.isarray": {
+                  "version": "3.0.3",
+                  "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.3.tgz"
+                }
+              }
             }
           }
         },
@@ -9078,19 +8729,29 @@
           }
         },
         "through2": {
-          "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
+          "version": "2.0.0",
+          "from": "through2@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.0.tgz",
           "dependencies": {
             "readable-stream": {
-              "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "version": "2.0.0",
+              "from": "readable-stream@>=2.0.0 <2.1.0",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
                   "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.1",
+                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
@@ -9102,16 +8763,16 @@
                   "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                "util-deprecate": {
+                  "version": "1.0.1",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "xtend@>=4.0.0 <4.1.0",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
@@ -9244,9 +8905,9 @@
       }
     },
     "gulp-typescript": {
-      "version": "2.7.6",
+      "version": "2.7.7",
       "from": "gulp-typescript@>=2.7.6 <2.8.0",
-      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-2.7.6.tgz",
+      "resolved": "https://registry.npmjs.org/gulp-typescript/-/gulp-typescript-2.7.7.tgz",
       "dependencies": {
         "source-map": {
           "version": "0.4.2",
@@ -9287,7 +8948,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -9306,13 +8967,13 @@
         },
         "vinyl-fs": {
           "version": "1.0.0",
-          "from": "vinyl-fs@>=1.0.0 <2.0.0",
+          "from": "vinyl-fs@>=1.0.0 <1.1.0",
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
           "dependencies": {
             "duplexify": {
-              "version": "3.4.1",
+              "version": "3.4.2",
               "from": "duplexify@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
@@ -9334,14 +8995,24 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "2.0.0",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.1",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -9353,10 +9024,10 @@
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
@@ -9502,7 +9173,7 @@
                       "dependencies": {
                         "xtend": {
                           "version": "4.0.0",
-                          "from": "xtend@>=4.0.0 <4.1.0",
+                          "from": "xtend@>=4.0.0 <4.1.0-0",
                           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
                         }
                       }
@@ -9668,7 +9339,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -9815,7 +9486,7 @@
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@>=0.0.2 <0.1.0",
+                  "from": "duplexer2@0.0.2",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
@@ -9840,7 +9511,7 @@
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -9875,7 +9546,7 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.3 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -9918,9 +9589,9 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
           "dependencies": {
             "duplexify": {
-              "version": "3.4.1",
+              "version": "3.4.2",
               "from": "duplexify@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
@@ -9942,14 +9613,24 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "2.0.0",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.1",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -9961,10 +9642,10 @@
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
@@ -10478,7 +10159,7 @@
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.6 <0.5.0",
+          "from": "vinyl@>=0.4.3 <0.5.0",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone": {
@@ -10533,9 +10214,9 @@
           "resolved": "https://registry.npmjs.org/through/-/through-2.3.7.tgz"
         },
         "webpack": {
-          "version": "1.9.10",
+          "version": "1.9.11",
           "from": "webpack@>=1.9.0 <2.0.0-0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.10.tgz",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.11.tgz",
           "dependencies": {
             "async": {
               "version": "0.9.2",
@@ -11021,9 +10702,9 @@
                   "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
                 },
                 "ieee754": {
-                  "version": "1.1.5",
+                  "version": "1.1.6",
                   "from": "ieee754@>=1.1.4 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+                  "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
                 },
                 "is-array": {
                   "version": "1.0.1",
@@ -11196,7 +10877,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@2.0.1",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -11293,9 +10974,9 @@
           "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.11.1.tgz",
           "dependencies": {
             "eventemitter3": {
-              "version": "1.1.0",
+              "version": "1.1.1",
               "from": "eventemitter3@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.1.1.tgz"
             },
             "requires-port": {
               "version": "0.0.1",
@@ -11334,9 +11015,9 @@
           "resolved": "https://registry.npmjs.org/character-parser/-/character-parser-1.2.1.tgz"
         },
         "clean-css": {
-          "version": "3.3.1",
+          "version": "3.3.3",
           "from": "clean-css@>=3.1.9 <4.0.0",
-          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.3.1.tgz",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.3.3.tgz",
           "dependencies": {
             "commander": {
               "version": "2.8.1",
@@ -11498,7 +11179,7 @@
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "async@>=0.2.6 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "source-map": {
@@ -11754,14 +11435,14 @@
       "resolved": "https://registry.npmjs.org/jshint-loader/-/jshint-loader-0.8.3.tgz",
       "dependencies": {
         "loader-utils": {
-          "version": "0.2.9",
-          "from": "loader-utils@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "version": "0.2.10",
+          "from": "loader-utils@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.0.2",
+              "version": "3.1.3",
               "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
@@ -11915,7 +11596,7 @@
                     },
                     "debug": {
                       "version": "2.2.0",
-                      "from": "debug@>=2.1.3 <3.0.0",
+                      "from": "debug@>=2.2.0 <2.3.0",
                       "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
                       "dependencies": {
                         "ms": {
@@ -12122,9 +11803,9 @@
           }
         },
         "colors": {
-          "version": "1.1.0",
+          "version": "1.1.2",
           "from": "colors@>=1.1.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
         },
         "connect": {
           "version": "2.29.2",
@@ -12235,7 +11916,7 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.13.0",
-                      "from": "mime-db@>=1.13.0 <2.0.0",
+                      "from": "mime-db@>=1.13.0 <1.14.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
@@ -12307,7 +11988,7 @@
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@>=2.1.3 <3.0.0",
+              "from": "debug@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "dependencies": {
                 "ms": {
@@ -12468,9 +12149,9 @@
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.5.3.tgz",
               "dependencies": {
                 "basic-auth": {
-                  "version": "1.0.1",
+                  "version": "1.0.2",
                   "from": "basic-auth@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.2.tgz"
                 },
                 "on-finished": {
                   "version": "2.2.1",
@@ -12697,7 +12378,7 @@
                   "dependencies": {
                     "mime-db": {
                       "version": "1.13.0",
-                      "from": "mime-db@>=1.13.0 <2.0.0",
+                      "from": "mime-db@>=1.13.0 <1.14.0",
                       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
@@ -12750,7 +12431,7 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
@@ -12829,9 +12510,9 @@
           }
         },
         "log4js": {
-          "version": "0.6.25",
+          "version": "0.6.26",
           "from": "log4js@>=0.6.25 <0.7.0",
-          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.25.tgz",
+          "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.26.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
@@ -13189,7 +12870,7 @@
         },
         "glob": {
           "version": "4.5.3",
-          "from": "glob@>=4.3.1 <5.0.0",
+          "from": "glob@>=4.0.3 <5.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
           "dependencies": {
             "inflight": {
@@ -13235,7 +12916,7 @@
             },
             "once": {
               "version": "1.3.2",
-              "from": "once@>=1.3.0 <1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
               "dependencies": {
                 "wrappy": {
@@ -13264,7 +12945,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
@@ -13338,9 +13019,9 @@
           "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-1.0.0.tgz",
           "dependencies": {
             "duplexify": {
-              "version": "3.4.1",
+              "version": "3.4.2",
               "from": "duplexify@>=3.2.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz",
+              "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
               "dependencies": {
                 "end-of-stream": {
                   "version": "1.0.0",
@@ -13362,14 +13043,24 @@
                   }
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
-                  "from": "readable-stream@>=1.1.13 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                  "version": "2.0.0",
+                  "from": "readable-stream@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
                       "from": "core-util-is@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.1",
+                      "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -13381,10 +13072,10 @@
                       "from": "string_decoder@>=0.10.0 <0.11.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "util-deprecate": {
+                      "version": "1.0.1",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                     }
                   }
                 }
@@ -13669,7 +13360,7 @@
       "dependencies": {
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.6.5 <0.7.0",
+          "from": "through2@>=0.6.1 <0.7.0",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
@@ -13694,7 +13385,7 @@
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -13741,9 +13432,9 @@
               "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz"
             },
             "ieee754": {
-              "version": "1.1.5",
+              "version": "1.1.6",
               "from": "ieee754@>=1.1.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.5.tgz"
+              "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.6.tgz"
             },
             "is-array": {
               "version": "1.0.1",
@@ -14053,7 +13744,7 @@
             },
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "inherits@>=2.0.0 <2.1.0",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "ini": {
@@ -14098,9 +13789,16 @@
               }
             },
             "osenv": {
-              "version": "0.1.1",
+              "version": "0.1.2",
               "from": "osenv@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                }
+              }
             },
             "semver": {
               "version": "4.3.6",
@@ -14194,9 +13892,9 @@
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
-              "version": "1.2.0",
+              "version": "2.0.0",
               "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "form-data": {
               "version": "0.1.4",
@@ -14333,14 +14031,14 @@
           "resolved": "https://registry.npmjs.org/extend-object/-/extend-object-1.0.0.tgz"
         },
         "loader-utils": {
-          "version": "0.2.9",
-          "from": "loader-utils@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.9.tgz",
+          "version": "0.2.10",
+          "from": "loader-utils@>=0.2.0 <0.3.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.10.tgz",
           "dependencies": {
             "big.js": {
-              "version": "3.0.2",
+              "version": "3.1.3",
               "from": "big.js@>=3.0.2 <4.0.0",
-              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
             },
             "json5": {
               "version": "0.4.0",
@@ -14838,14 +14536,19 @@
           "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
         },
         "request": {
-          "version": "2.57.0",
+          "version": "2.58.0",
           "from": "request@>=2.45.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.57.0.tgz",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.58.0.tgz",
           "dependencies": {
             "caseless": {
               "version": "0.10.0",
               "from": "caseless@>=0.10.0 <0.11.0",
               "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.10.0.tgz"
+            },
+            "extend": {
+              "version": "2.0.1",
+              "from": "extend@>=2.0.1 <2.1.0",
+              "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
             },
             "forever-agent": {
               "version": "0.6.1",
@@ -14853,24 +14556,24 @@
               "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
             },
             "form-data": {
-              "version": "0.2.0",
-              "from": "form-data@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+              "version": "1.0.0-rc1",
+              "from": "form-data@>=1.0.0-rc1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-1.0.0-rc1.tgz",
               "dependencies": {
                 "async": {
-                  "version": "0.9.2",
-                  "from": "async@>=0.9.0 <0.10.0",
-                  "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+                  "version": "1.2.1",
+                  "from": "async@>=1.2.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz"
                 },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@>=0.0.4 <0.1.0",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                "mime-types": {
+                  "version": "2.1.1",
+                  "from": "mime-types@>=2.1.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.1.tgz",
                   "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    "mime-db": {
+                      "version": "1.13.0",
+                      "from": "mime-db@>=1.13.0 <1.14.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.13.0.tgz"
                     }
                   }
                 }
@@ -14909,9 +14612,9 @@
               "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
             },
             "tough-cookie": {
-              "version": "1.2.0",
+              "version": "2.0.0",
               "from": "tough-cookie@>=0.12.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.0.0.tgz"
             },
             "http-signature": {
               "version": "0.11.0",
@@ -14951,9 +14654,9 @@
                   "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
                 },
                 "boom": {
-                  "version": "2.7.2",
+                  "version": "2.8.0",
                   "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.8.0.tgz"
                 },
                 "cryptiles": {
                   "version": "2.0.4",
@@ -14978,13 +14681,13 @@
               "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
             },
             "combined-stream": {
-              "version": "1.0.3",
+              "version": "1.0.5",
               "from": "combined-stream@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.3.tgz",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <2.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
                 }
               }
@@ -15000,9 +14703,9 @@
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.1.tgz",
               "dependencies": {
                 "bluebird": {
-                  "version": "2.9.27",
+                  "version": "2.9.30",
                   "from": "bluebird@>=2.9.26 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.27.tgz"
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.30.tgz"
                 },
                 "commander": {
                   "version": "2.8.1",
@@ -15118,7 +14821,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -15130,7 +14833,7 @@
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.0 <0.3.0",
+                      "from": "ansi-regex@>=0.2.1 <0.3.0",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
@@ -15182,9 +14885,16 @@
                   "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
                 },
                 "osenv": {
-                  "version": "0.1.1",
+                  "version": "0.1.2",
                   "from": "osenv@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.1.tgz"
+                  "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.2.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.1",
+                      "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
+                    }
+                  }
                 },
                 "user-home": {
                   "version": "1.1.1",
@@ -15219,9 +14929,9 @@
                       "resolved": "https://registry.npmjs.org/got/-/got-3.2.0.tgz",
                       "dependencies": {
                         "duplexify": {
-                          "version": "3.4.1",
+                          "version": "3.4.2",
                           "from": "duplexify@>=3.2.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.1.tgz",
+                          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                           "dependencies": {
                             "end-of-stream": {
                               "version": "1.0.0",
@@ -15243,14 +14953,24 @@
                               }
                             },
                             "readable-stream": {
-                              "version": "1.1.13",
-                              "from": "readable-stream@>=1.1.13 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
+                              "version": "2.0.0",
+                              "from": "readable-stream@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.0.tgz",
                               "dependencies": {
                                 "core-util-is": {
                                   "version": "1.0.1",
                                   "from": "core-util-is@>=1.0.0 <1.1.0",
                                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                                },
+                                "process-nextick-args": {
+                                  "version": "1.0.1",
+                                  "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.1.tgz"
+                                },
+                                "inherits": {
+                                  "version": "2.0.1",
+                                  "from": "inherits@>=2.0.1 <2.1.0",
+                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                                 },
                                 "isarray": {
                                   "version": "0.0.1",
@@ -15262,10 +14982,10 @@
                                   "from": "string_decoder@>=0.10.0 <0.11.0",
                                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                                 },
-                                "inherits": {
-                                  "version": "2.0.1",
-                                  "from": "inherits@>=2.0.1 <2.1.0",
-                                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                                "util-deprecate": {
+                                  "version": "1.0.1",
+                                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                                 }
                               }
                             }
@@ -15441,9 +15161,9 @@
       "resolved": "https://registry.npmjs.org/uglify-save-license/-/uglify-save-license-0.4.1.tgz"
     },
     "webpack": {
-      "version": "1.9.10",
+      "version": "1.9.11",
       "from": "webpack@*",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.10.tgz",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-1.9.11.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",


### PR DESCRIPTION
[gulp-jscs](https://github.com/jscs-dev/gulp-jscs) is not enough stable:

* strange behavior with option `fix` who force to define path of configFile
* break gulp process if one error is found unlike gulp-jshint

Walkthrough:
use https://www.npmjs.com/package/jscs like a global package

fix #609 
fix #607 
