### PR TITLE
Fix import file path

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -32,8 +32,8 @@ gulp.task('styles', function () {
 
   var injectOptions = {
     transform: function(filePath) {
-      filePath = filePath.replace(path.join(conf.paths.src, '/app/'), '');
-      return '@import \'' + filePath + '\';';
+      filePath = filePath.replace(conf.paths.src + '/app/', '');
+      return '@import "' + filePath + '";';
     },
     starttag: '// injector',
     endtag: '// endinjector',


### PR DESCRIPTION
close #601 
close #618 
close #592

Import path in styles task don't need `path.join` and single quote.
`path.join` modify path relative to OS  => replace function don't match to string.