### PR TITLE
add baseUrl to protractor conf

### DIFF
--- a/app/templates/e2e/main.spec.js
+++ b/app/templates/e2e/main.spec.js
@@ -4,7 +4,7 @@ describe('The main view', function () {
   var page;
 
   beforeEach(function () {
-    browser.get('http://localhost:3000/index.html');
+    browser.get('/index.html');
     page = require('./main.po');
   });
 

--- a/app/templates/protractor.conf.js
+++ b/app/templates/protractor.conf.js
@@ -12,6 +12,8 @@ exports.config = {
   capabilities: {
     'browserName': 'chrome'
   },
+  
+  baseUrl: 'http://localhost:3000',
 
   // Spec patterns are relative to the current working directly when
   // protractor is called.


### PR DESCRIPTION
avoids to write browser.get('http://localhost:3000/mypage') all the time
see https://github.com/angular/protractor/blob/2.1.0/docs/referenceConf.js#L160