### PR TITLE
Changed TypeScript index.module classes to functions

### DIFF
--- a/app/templates/src/app/_index.config.ts
+++ b/app/templates/src/app/_index.config.ts
@@ -2,7 +2,7 @@ module <%- appName %> {
   'use strict';
 
   /** @ngInject */
-  export function Config($logProvider: ng.ILogProvider, toastr: Toastr) {
+  export function config($logProvider: ng.ILogProvider, toastr: Toastr) {
     // enable log
     $logProvider.debugEnabled(true);
     // set options third-party lib

--- a/app/templates/src/app/_index.config.ts
+++ b/app/templates/src/app/_index.config.ts
@@ -1,17 +1,14 @@
 module <%- appName %> {
   'use strict';
 
-  export class Config {
-    /** @ngInject */
-    constructor($logProvider: ng.ILogProvider, toastr: Toastr) {
-      // enable log
-      $logProvider.debugEnabled(true);
-      // set options third-party lib
-      toastr.options.timeOut = 3000;
-      toastr.options.positionClass = 'toast-top-right';
-      toastr.options.preventDuplicates = true;
-      toastr.options.progressBar = true;
-    }
-
+  /** @ngInject */
+  export function Config($logProvider: ng.ILogProvider, toastr: Toastr) {
+    // enable log
+    $logProvider.debugEnabled(true);
+    // set options third-party lib
+    toastr.options.timeOut = 3000;
+    toastr.options.positionClass = 'toast-top-right';
+    toastr.options.preventDuplicates = true;
+    toastr.options.progressBar = true;
   }
 }

--- a/app/templates/src/app/_index.module.ts
+++ b/app/templates/src/app/_index.module.ts
@@ -22,11 +22,11 @@ module <%- appName %> {
     .constant('malarkey', malarkey)
     .constant('toastr', toastr)
     .constant('moment', moment)
-    .config(Config)
+    .config(config)
 <% if (props.router.key !== 'none') { %>
-    .config(RouterConfig)
+    .config(routerConfig)
 <% } %>
-    .run(RunBlock)
+    .run(runBlock)
     .service('githubContributor', GithubContributor)
     .service('webDevTec', WebDevTecService)
     .controller('MainController', MainController)

--- a/app/templates/src/app/_index.run.ts
+++ b/app/templates/src/app/_index.run.ts
@@ -1,11 +1,8 @@
 module <%- appName %> {
   'use strict';
 
-  export class RunBlock {
-    /** @ngInject */
-    constructor($log: ng.ILogService) {
-      $log.debug('runBlock end');
-    }
-
+  /** @ngInject */
+  export function RunBlock($log: ng.ILogService) {
+    $log.debug('runBlock end');
   }
 }

--- a/app/templates/src/app/_index.run.ts
+++ b/app/templates/src/app/_index.run.ts
@@ -2,7 +2,7 @@ module <%- appName %> {
   'use strict';
 
   /** @ngInject */
-  export function RunBlock($log: ng.ILogService) {
+  export function runBlock($log: ng.ILogService) {
     $log.debug('runBlock end');
   }
 }

--- a/app/templates/src/app/_ngroute/__ngroute.ts
+++ b/app/templates/src/app/_ngroute/__ngroute.ts
@@ -1,18 +1,15 @@
 module <%- appName %> {
   'use strict';
 
-  export class RouterConfig {
-    /** @ngInject */
-    constructor($routeProvider: ng.route.IRouteProvider) {
-      $routeProvider
-        .when('/', {
-          templateUrl: 'app/main/main.html',
-          controller: 'MainController',
-          controllerAs: 'main'
-        })
-        .otherwise({
-          redirectTo: '/'
-        });
-    }
+  /** @ngInject */
+  export function RouterConfig($routeProvider: ng.route.IRouteProvider) {
+    $routeProvider
+      .when('/', {
+        templateUrl: 'app/main/main.html',
+        controller: 'MainController',
+        controllerAs: 'main'
+      })
+      .otherwise({
+        redirectTo: '/'
+      });
   }
-}

--- a/app/templates/src/app/_ngroute/__ngroute.ts
+++ b/app/templates/src/app/_ngroute/__ngroute.ts
@@ -2,7 +2,7 @@ module <%- appName %> {
   'use strict';
 
   /** @ngInject */
-  export function RouterConfig($routeProvider: ng.route.IRouteProvider) {
+  export function routerConfig($routeProvider: ng.route.IRouteProvider) {
     $routeProvider
       .when('/', {
         templateUrl: 'app/main/main.html',

--- a/app/templates/src/app/_uirouter/__uirouter.ts
+++ b/app/templates/src/app/_uirouter/__uirouter.ts
@@ -2,7 +2,7 @@ module <%- appName %> {
   'use strict';
 
   /** @ngInject */
-  export function RouterConfig($stateProvider: ng.ui.IStateProvider, $urlRouterProvider: ng.ui.IUrlRouterProvider) {
+  export function routerConfig($stateProvider: ng.ui.IStateProvider, $urlRouterProvider: ng.ui.IUrlRouterProvider) {
     $stateProvider
       .state('home', {
         url: '/',

--- a/app/templates/src/app/_uirouter/__uirouter.ts
+++ b/app/templates/src/app/_uirouter/__uirouter.ts
@@ -1,19 +1,16 @@
 module <%- appName %> {
   'use strict';
 
-  export class RouterConfig {
-    /** @ngInject */
-    constructor($stateProvider: ng.ui.IStateProvider, $urlRouterProvider: ng.ui.IUrlRouterProvider) {
-      $stateProvider
-        .state('home', {
-          url: '/',
-          templateUrl: 'app/main/main.html',
-          controller: 'MainController',
-          controllerAs: 'main'
-        });
+  /** @ngInject */
+  export function RouterConfig($stateProvider: ng.ui.IStateProvider, $urlRouterProvider: ng.ui.IUrlRouterProvider) {
+    $stateProvider
+      .state('home', {
+        url: '/',
+        templateUrl: 'app/main/main.html',
+        controller: 'MainController',
+        controllerAs: 'main'
+      });
 
-      $urlRouterProvider.otherwise('/');
-    }
-
+    $urlRouterProvider.otherwise('/');    
   }
 }

--- a/test/template/test-index-module-js.js
+++ b/test/template/test-index-module-js.js
@@ -54,13 +54,13 @@ describe('gulp-angular index js template', function () {
     var result = indexEs6(model);
     result.should.match(/.config\(routerConfig\)/);
     result = indexTs(model);
-    result.should.match(/.config\(RouterConfig\)/);
+    result.should.match(/.config\(routerConfig\)/);
 
     model.props.router.key = 'none';
     result = indexEs6(model);
     result.should.not.match(/.config\(routerConfig\)/);
     result = indexTs(model);
-    result.should.not.match(/.config\(RouterConfig\)/);
+    result.should.not.match(/.config\(routerConfig\)/);
   });
 
 });


### PR DESCRIPTION
This fixes #629.

index.ts was split into several files: index.module.ts, index.config.ts, index.route.ts, and index.run.ts. The last three files in that list each defined classes to encapsulate their functionality. However, in the index.module.ts, the classes were being passed to the angular module.config() and module.run(), but Angular doesn't call these functions with the new keyword, meaning they should just be functions. Having them as classes didn't actually break anything, but when trying to use `this` in the constructor, you got `undefined` (in strict mode) or `window` otherwise. Changing these implementations to just `export function` will prevent devs from writing code as though it's a constructor.