### PR TITLE
Change the build root

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -24,7 +24,7 @@ gulp.task('partials', ['markups'], function () {
     }))
     .pipe($.angularTemplatecache('templateCacheHtml.js', {
       module: '<%- appName %>',
-      root: 'app'
+      root: '/app'
     }))
     .pipe(gulp.dest(conf.paths.tmp + '/partials/'));
 });


### PR DESCRIPTION
Change to root from "app" to "/app" so that the angular template cache would work properly after using "gulp build".