### PR TITLE
Exclude JS preprocessor unit tests from inject

### DIFF
--- a/app/templates/gulp/_inject.js
+++ b/app/templates/gulp/_inject.js
@@ -29,6 +29,8 @@ gulp.task('inject', ['scripts'], function () {
 <% } if (props.jsPreprocessor.key !== 'none') { -%>
     path.join(conf.paths.tmp, '/serve/app/**/*.module.js'),
     path.join(conf.paths.tmp, '/serve/app/**/*.js'),
+    path.join('!' + conf.paths.tmp, '/serve/app/**/*.spec.js'),
+    path.join('!' + conf.paths.tmp, '/serve/app/**/*.mock.js'),
 <% } -%>
     path.join('!' + conf.paths.src, '/app/**/*.spec.js'),
     path.join('!' + conf.paths.src, '/app/**/*.mock.js')


### PR DESCRIPTION
This applies to unit tests written with a JS preproccessor such as CoffeeScript.
These tests are placed in tmp/serve after being compiled to JS, and were previously
not being excluded from inject.

closes #657