### PR TITLE
Fix Zepto option

### DIFF
--- a/app/src/bower.js
+++ b/app/src/bower.js
@@ -50,7 +50,7 @@ module.exports = function(GulpAngularGenerator) {
    */
   GulpAngularGenerator.prototype.computeWiredepExclusions = function computeWiredepExclusions() {
     this.wiredepExclusions = [];
-    if (this.props.jQuery.key === 'none') {
+    if (this.props.jQuery.key === 'none' || this.props.jQuery.key === 'zepto') {
       this.wiredepExclusions.push('/jquery/');
     }
     if (this.props.ui.key === 'bootstrap') {

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -17,7 +17,7 @@
 <% } if (props.jQuery.key === 'jquery2') { -%>
     "jquery": "~2.1.4",
 <% } if (props.jQuery.key === 'zepto') { -%>
-    "zeptojs": "~1.1.6",
+    "zepto": "~1.1.6",
 <% } if (props.resource.key === 'angular-resource') { -%>
     "angular-resource": "<%- props.angularVersion %>",
 <% } if (props.resource.key === 'restangular') { -%>

--- a/test/node/test-bower.js
+++ b/test/node/test-bower.js
@@ -174,6 +174,17 @@ describe('gulp-angular generator bower script', function () {
       generator.computeWiredepExclusions();
       generator.wiredepExclusions[0].should.be.equal('/jquery/');
     });
+
+    it('should exclude jQuery with Zepto', function() {
+      generator.props = {
+        jQuery: { key: 'zepto' },
+        ui: { key: 'foundation' },
+        foundationComponents: { key: 'official' },
+        cssPreprocessor: { key: 'none' }
+      };
+      generator.computeWiredepExclusions();
+      generator.wiredepExclusions[0].should.be.equal('/jquery/');
+    });
   });
 
 });


### PR DESCRIPTION
We was using the source repo of zepto with no bower conf and no dist package. I switched on the "shim" repo.

I also exclude jquery when selecting Zepto as I think we can suppose that choosing Zepto mean we don't want to use jQuery.

Should fix #663