### PR TITLE
Add dist sourcemaps

### DIFF
--- a/app/templates/gulp/_build.js
+++ b/app/templates/gulp/_build.js
@@ -47,10 +47,13 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(assets = $.useref.assets())
     .pipe($.rev())
     .pipe(jsFilter)
+    .pipe($.sourcemaps.init())
     .pipe($.ngAnnotate())
     .pipe($.uglify({ preserveComments: $.uglifySaveLicense })).on('error', conf.errorHandler('Uglify'))
+    .pipe($.sourcemaps.write('maps'))
     .pipe(jsFilter.restore())
     .pipe(cssFilter)
+    .pipe($.sourcemaps.init())
 <% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'scss') { -%>
     .pipe($.replace('../<%- computedPaths.appToBower %>/bower_components/bootstrap-sass-official/assets/fonts/bootstrap/', '../fonts/'))
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'less') { -%>
@@ -59,6 +62,7 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe($.replace('../<%- computedPaths.appToBower %>/bower_components/bootstrap-stylus/fonts/', '../fonts/'))
 <% } -%>
     .pipe($.minifyCss({ processImport: false }))
+    .pipe($.sourcemaps.write('maps'))
     .pipe(cssFilter.restore())
     .pipe(assets.restore())
     .pipe($.useref())
@@ -73,8 +77,9 @@ gulp.task('html', ['inject', 'partials'], function () {
     .pipe(htmlFilter.restore())
     .pipe(gulp.dest(path.join(conf.paths.dist, '/')))
     .pipe($.size({ title: path.join(conf.paths.dist, '/'), showFiles: true }));
-});
+  });
 <% if (imageMin) { -%>
+
 gulp.task('images', function () {
   return gulp.src(path.join(conf.paths.src, '/assets/images/**/*'))
     .pipe($.imagemin({


### PR DESCRIPTION
Useref now support sourcemaps which is great! jonkemp/gulp-useref#64

Here's a first try using it. But I can't get the original filepaths even if having identation and var name is already far better than what we have.

If someone has any idea to improve this, I'm all aware.

Thanks from @dereklin and @wgorder in #630

I used external mapping thinking that in production you don't want your final users to download extra data for sourcemaps only those with dev tools.

This open the question of how to disable it because people will want to be able to turn it off.