### PR TITLE
Allow manual @import of Sass partials

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -27,6 +27,7 @@ gulp.task('styles', function () {
 
   var injectFiles = gulp.src([
     path.join(conf.paths.src, '/app/**/*.<%- props.cssPreprocessor.extension %>'),
+    path.join('!' + conf.paths.src, '/app/**/*_.<%- props.cssPreprocessor.extension %>'),
     path.join('!' + conf.paths.src, '/app/index.<%- props.cssPreprocessor.extension %>')
   ], { read: false });
 


### PR DESCRIPTION
Whenever I scaffold with this generator I've ended up adding this single line.

I hate having everything in a single `index.scss` so I create partials with filenames prefixed by `_` (e.g. `_variables.scss`, `_mixins.scss`) which often need to be loaded in a specific order.  

My `index.scss` often ends up looking something like this:

```scss
@import 'core/styles/variables';
@import 'core/styles/mixins';
// etc, etc...

/**
 *  Do not remove this comments bellow. It's the markers used by wiredep to inject
 *  sass dependencies when defined in the bower.json of your dependencies
 */
// bower:scss
// endbower

/**
 *  Do not remove this comments bellow. It's the markers used by gulp-inject to inject
 *  all your sass files automatically
 */
// injector
// endinjector
```

By ignoring the `_`-prefixed partials along with `index.scss` in the `styles.js` Gulp file, this allows the developer to `@import` whichever files he or she wishes in whatever order, rather than leaving it up to the rest of the Gulp tasks.

In the project on which I am currently working, this changes the original `styles.js` at line 19 from:

```js
  var injectFiles = gulp.src([
    path.join(conf.paths.src, '/app/**/*.scss'),
    path.join('!' + conf.paths.src, '/app/index.scss')
  ], { read: false });
```

...to this:

```js
  var injectFiles = gulp.src([
    path.join(conf.paths.src, '/app/**/*.scss'),
    path.join('!' + conf.paths.src, '/app/**/_*.scss'),
    path.join('!' + conf.paths.src, '/app/index.scss')
  ], { read: false });
```

Sorry, still new to contributing--let me know if there's anything I could have done better. 

Cheers :)