### PR TITLE
Refactor: Use CoffeeScript's default value arg in githubContributor service

### DIFF
--- a/app/templates/src/app/components/githubContributor/_githubContributor.service.coffee
+++ b/app/templates/src/app/components/githubContributor/_githubContributor.service.coffee
@@ -3,7 +3,7 @@ angular.module '<%- appName %>'
     'ngInject'
     apiHost = 'https://api.github.com/repos/Swiip/generator-gulp-angular'
 
-    getContributors = (limit) ->
+    getContributors = (limit=30) ->
 
       getContributorsComplete = (response) ->
         response.data
@@ -12,8 +12,6 @@ angular.module '<%- appName %>'
         $log.error 'XHR Failed for getContributors.\n' + angular.toJson(error.data, true)
         return
 
-      if !limit
-        limit = 30
       $http.get(apiHost + '/contributors?per_page=' + limit).then(getContributorsComplete).catch getContributorsFailed
 
     service =


### PR DESCRIPTION
Both TypeScript and CoffeeScript support function arguments with default values, yet the sample `githubContributor` service in TS makes use of the feature:

```
getContributors(limit: number = 30) {
  return this.$http.get(this.apiHost + '/contributors?per_page=' + limit)
```

and the CS equivalent doesn't:

```
if !limit
  limit = 30
```

This PR aims make it fair for my beloved CoffeeScript.