### PR TITLE
Update version of Angular Material

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -43,7 +43,7 @@
 <% } if(props.ui.key === 'foundation') { -%>
     "foundation": "~5.5.2",
 <% } if(props.ui.key === 'angular-material') { -%>
-    "angular-material": "~0.10.1",
+    "angular-material": "~0.11.2",
     "material-design-iconfont": "~0.0.2",
 <% } if(props.ui.key === 'material-design-lite') { -%>
     "material-design-lite": "~1.0.4",


### PR DESCRIPTION
I've used this generator for creating my Angular app template and encountered an issue when I was unable to use md-datepicker because of the old Angular Material version. I've updated version manually and everything working perfectly right now.