### PR TITLE
Fix tests with pre processed markup

### DIFF
--- a/app/templates/_karma.conf.js
+++ b/app/templates/_karma.conf.js
@@ -10,7 +10,7 @@ var pathSrcHtml = [
 <% if (props.htmlPreprocessor.key === 'noHtmlPrepro') { -%>
   path.join(conf.paths.src, '/**/*.html')
 <% } else { -%>
-  path.join(conf.paths.tmp, '/serve/app/**/*.html'),
+  path.join(conf.paths.tmp, '/serve/**/*.html'),
   path.join(conf.paths.src, '/**/*.html')
 <% } -%>
 ];
@@ -50,7 +50,11 @@ module.exports = function(config) {
     autoWatch: false,
 
     ngHtml2JsPreprocessor: {
+<% if (props.htmlPreprocessor.key === 'noHtmlPrepro') { -%>
       stripPrefix: conf.paths.src + '/',
+<% } else { -%>
+      stripPrefix: '(' + conf.paths.src + '/|' + conf.paths.tmp + '/serve/)',
+<% } -%>
       moduleName: '<%- appName %>'
     },
 

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -80,6 +80,7 @@
     "karma-chrome-launcher": "~0.2.0",
 <% } else { -%>
     "karma-phantomjs-launcher": "~0.2.1",
+    "phantomjs": "~1.9.18",
 <% } if (props.jsPreprocessor.srcExtension === 'js' || props.jsPreprocessor.srcExtension === 'coffee') { -%>
     "karma-angular-filesort": "~1.0.0",
 <% } -%>

--- a/app/templates/gulp/_unit-tests.js
+++ b/app/templates/gulp/_unit-tests.js
@@ -10,7 +10,7 @@ var pathSrcHtml = [
 <% if (props.htmlPreprocessor.key === 'noHtmlPrepro') { -%>
   path.join(conf.paths.src, '/**/*.html')
 <% } else { -%>
-  path.join(conf.paths.tmp, '/serve/app/**/*.html'),
+  path.join(conf.paths.tmp, '/serve/**/*.html'),
   path.join(conf.paths.src, '/**/*.html')
 <% } -%>
 ];
@@ -55,7 +55,7 @@ function runTests (singleRun, done) {
 }
 
 <% if (props.jsPreprocessor.srcExtension !== 'es6' && props.jsPreprocessor.key !== 'typescript') { -%>
-gulp.task('test', ['scripts'], function(done) {
+gulp.task('test', ['scripts'<% if (props.htmlPreprocessor.key !== 'noHtmlPrepro') { %>, 'markups'<% } %>], function(done) {
   runTests(true, done);
 });
 
@@ -63,7 +63,7 @@ gulp.task('test:auto', ['watch'], function(done) {
   runTests(false, done);
 });
 <% } else { -%>
-gulp.task('test', ['scripts:test'], function(done) {
+gulp.task('test', ['scripts:test'<% if (props.htmlPreprocessor.key !== 'noHtmlPrepro') { %>, 'markups'<% } %>], function(done) {
   runTests(true, done);
 });
 


### PR DESCRIPTION
As mentioned in #802 and #731, tests using preprocessed templates was still not working.

It missed the `stripPrefix` option from ng-html2js for files loaded in .tmp. Fortunately it can takes regexp and I proposed a generic replacement value.

I also added PhantomJS as a direct deps because NPM3 doesn't load peer dependencies by default anymore. I still have issues using Karma without Gulp with NPM3 (but this PR can be merged because it's at least better).