### PR TITLE
chore: bump gulp-load-plugins

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,7 @@
 <% } -%>
     "gulp-eslint": "~1.0.0",
     "eslint-plugin-angular": "~0.12.0",
-    "gulp-load-plugins": "~0.10.0",
+    "gulp-load-plugins": "~1.0.0",
     "gulp-size": "~2.0.0",
     "gulp-uglify": "~1.4.1",
     "gulp-useref": "~1.3.0",


### PR DESCRIPTION
The breaking change is removed NODE_PATH support, which isn't used in this
project.

Note, `npm run update-shrinkwrap` does not finish on my system/takes longer
than an hour, so I can't include it.