### PR TITLE
Update sassOptions object to reflect correct property name

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -21,7 +21,7 @@ gulp.task('styles', function () {
   };
 <% } if (props.cssPreprocessor.extension === 'scss') { -%>
   var sassOptions = {
-    style: 'expanded'
+    outputStyle: 'expanded'
   };
 <% } -%>
 


### PR DESCRIPTION
I noticed the `style` value was being ignored in `sassOptions`, this is because `gulp-sass` (via `node-sass`) uses `outputStyle` as the output-style property. Updated here.

See [https://github.com/sass/node-sass#outputstyle](https://github.com/sass/node-sass#outputstyle).