### PR TITLE
Update sassOptions object to reflect correct property name

### DIFF
--- a/app/templates/gulp/_styles.js
+++ b/app/templates/gulp/_styles.js
@@ -21,7 +21,7 @@ gulp.task('styles', function () {
   };
 <% } if (props.cssPreprocessor.extension === 'scss') { -%>
   var sassOptions = {
-    style: 'expanded'
+    outputStyle: 'expanded'
   };
 <% } -%>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-gulp-angular",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "preferGlobal": true,
   "description": "Yeoman generator for AngularJS with Gulp",
   "keywords": "yeoman-generator, angular, gulp, restangular, ui-router, bootstrap, angular-material, foundation, sass, less, es6, babel, traceur, typescript, coffeescript, jade, haml, webpack, eslint",


### PR DESCRIPTION
I noticed the `style` value was being ignored in `sassOptions`, this is because `gulp-sass` (via `node-sass`) uses `outputStyle` as the output-style property. Updated here.

See [https://github.com/sass/node-sass#outputstyle](https://github.com/sass/node-sass#outputstyle).