### PR TITLE
Style/typescript improvements

### DIFF
--- a/generators/app/templates/src/app/_index.config.ts
+++ b/generators/app/templates/src/app/_index.config.ts
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function config($logProvider: ng.ILogProvider, toastrConfig: any) {
+export function config($logProvider: angular.ILogProvider, toastrConfig: any) {
   // enable log
   $logProvider.debugEnabled(true);
   // set options third-party lib

--- a/generators/app/templates/src/app/_index.run.ts
+++ b/generators/app/templates/src/app/_index.run.ts
@@ -1,4 +1,4 @@
 /** @ngInject */
-export function runBlock($log: ng.ILogService) {
+export function runBlock($log: angular.ILogService) {
   $log.debug('runBlock end');
 }

--- a/generators/app/templates/src/app/_ngroute/__ngroute.ts
+++ b/generators/app/templates/src/app/_ngroute/__ngroute.ts
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function routerConfig($routeProvider: ng.route.IRouteProvider) {
+export function routerConfig($routeProvider: angular.route.IRouteProvider) {
   $routeProvider
     .when('/', {
       templateUrl: 'app/main/main.html',

--- a/generators/app/templates/src/app/_uirouter/__uirouter.ts
+++ b/generators/app/templates/src/app/_uirouter/__uirouter.ts
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function routerConfig($stateProvider: ng.ui.IStateProvider, $urlRouterProvider: ng.ui.IUrlRouterProvider) {
+export function routerConfig($stateProvider: angular.ui.IStateProvider, $urlRouterProvider: angular.ui.IUrlRouterProvider) {
   $stateProvider
     .state('home', {
       url: '/',

--- a/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.spec.ts
+++ b/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.spec.ts
@@ -8,7 +8,7 @@ describe('service githubContributor', () => {
   }));
 
   describe('getContributors function', () => {
-    it('should return data', inject((githubContributor: GithubContributor, $httpBackend: ng.IHttpBackendService) => {
+    it('should return data', inject((githubContributor: GithubContributor, $httpBackend: angular.IHttpBackendService) => {
       $httpBackend.when('GET',  githubContributor.apiHost + '/contributors?per_page=1').respond(200, [{pprt: 'value'}]);
       let data: any[];
       githubContributor.getContributors(1).then((fetchedData: any[]) => {
@@ -19,7 +19,7 @@ describe('service githubContributor', () => {
       expect(data[0]).not.toBeNull();
     }));
 
-    it('should define a limit per page as default value', inject((githubContributor: GithubContributor, $httpBackend: ng.IHttpBackendService) => {
+    it('should define a limit per page as default value', inject((githubContributor: GithubContributor, $httpBackend: angular.IHttpBackendService) => {
       $httpBackend.when('GET',  githubContributor.apiHost + '/contributors?per_page=30').respond(200, new Array(30));
       var data: any[];
       githubContributor.getContributors().then((fetchedData: any[]) => {
@@ -29,7 +29,7 @@ describe('service githubContributor', () => {
       expect(data.length === 30).toBeTruthy();
     }));
 
-    it('should log a error', inject((githubContributor: GithubContributor, $httpBackend: ng.IHttpBackendService, $log: ng.ILogService) => {
+    it('should log a error', inject((githubContributor: GithubContributor, $httpBackend: angular.IHttpBackendService, $log: angular.ILogService) => {
       $httpBackend.when('GET', githubContributor.apiHost + '/contributors?per_page=1').respond(500);
       githubContributor.getContributors(1);
       $httpBackend.flush();

--- a/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.ts
+++ b/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.ts
@@ -1,16 +1,16 @@
 export class GithubContributor {
   public apiHost: string = 'https://api.github.com/repos/Swiip/generator-gulp-angular';
 
-  private $log: ng.ILogService;
-  private $http: ng.IHttpService;
+  private $log: angular.ILogService;
+  private $http: angular.IHttpService;
 
   /** @ngInject */
-  constructor($log: ng.ILogService, $http: ng.IHttpService) {
+  constructor($log: angular.ILogService, $http: angular.IHttpService) {
     this.$log = $log;
     this.$http = $http;
   }
 
-  getContributors(limit: number = 30): ng.IPromise<any[]> {
+  getContributors(limit: number = 30): angular.IPromise<any[]> {
     return this.$http.get(this.apiHost + '/contributors?per_page=' + limit)
       .then((response: any): any => {
         return response.data;

--- a/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.ts
+++ b/generators/app/templates/src/app/components/githubContributor/_githubContributor.service.ts
@@ -1,13 +1,9 @@
 export class GithubContributor {
   public apiHost: string = 'https://api.github.com/repos/Swiip/generator-gulp-angular';
 
-  private $log: angular.ILogService;
-  private $http: angular.IHttpService;
-
   /** @ngInject */
-  constructor($log: angular.ILogService, $http: angular.IHttpService) {
-    this.$log = $log;
-    this.$http = $http;
+  constructor(private $log: angular.ILogService, private $http: angular.IHttpService) {
+
   }
 
   getContributors(limit: number = 30): angular.IPromise<any[]> {

--- a/generators/app/templates/src/app/components/malarkey/_malarkey.directive.spec.ts
+++ b/generators/app/templates/src/app/components/malarkey/_malarkey.directive.spec.ts
@@ -8,12 +8,12 @@ import { GithubContributor } from '../githubContributor/githubContributor.servic
  * (malarkey usage, addClass, $watch, $destroy)
  */
 describe('directive malarkey', () => {
-  let element: ng.IAugmentedJQuery;
+  let element: angular.IAugmentedJQuery;
   let malarkeyController: MalarkeyController;
 
   beforeEach(angular.mock.module('<%- appName %>'));
 
-  beforeEach(inject(($compile: ng.ICompileService, $rootScope: ng.IRootScopeService, githubContributor: GithubContributor, $q: ng.IQService) => {
+  beforeEach(inject(($compile: angular.ICompileService, $rootScope: angular.IRootScopeService, githubContributor: GithubContributor, $q: angular.IQService) => {
     spyOn(githubContributor, 'getContributors').and.callFake(() => {
       return  $q.when([{}, {}, {}, {}, {}, {}]);
     });
@@ -37,7 +37,7 @@ describe('directive malarkey', () => {
     expect(malarkeyController.contributors.length).toEqual(6);
   });
 
-  it('should log a info', inject(($log: ng.ILogService) => {
+  it('should log a info', inject(($log: angular.ILogService) => {
     expect($log.info.logs).toEqual(jasmine.stringMatching('Activated Contributors View'));
   }));
 });

--- a/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
+++ b/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
@@ -57,13 +57,11 @@ export class MalarkeyController {
   public contributors: any[];
   public malarkey: any;
 
-  private $log: angular.ILogService;
   private githubContributor: GithubContributor;
 
-  constructor($log: angular.ILogService, githubContributor: GithubContributor, malarkey: any) {
+  constructor(private $log: angular.ILogService, githubContributor: GithubContributor, malarkey: any) {
     this.contributors = [];
 
-    this.$log = $log;
     this.githubContributor = githubContributor;
     this.malarkey = malarkey;
 

--- a/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
+++ b/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
@@ -55,15 +55,10 @@ export interface IContributor {
 /** @ngInject */
 export class MalarkeyController {
   public contributors: any[];
-  public malarkey: any;
 
-  private githubContributor: GithubContributor;
 
-  constructor(private $log: angular.ILogService, githubContributor: GithubContributor, malarkey: any) {
+  constructor(private $log: angular.ILogService, private githubContributor: GithubContributor, private malarkey: any) {
     this.contributors = [];
-
-    this.githubContributor = githubContributor;
-    this.malarkey = malarkey;
 
     this.activate();
   }

--- a/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
+++ b/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
@@ -1,11 +1,11 @@
 import { GithubContributor } from '../githubContributor/githubContributor.service';
 
-interface IProjectsScope extends ng.IScope {
+interface IProjectsScope extends angular.IScope {
   extraValues: any[];
 }
 
 /** @ngInject */
-export function acmeMalarkey(malarkey: any): ng.IDirective {
+export function acmeMalarkey(malarkey: any): angular.IDirective {
 
   return {
     restrict: 'E',
@@ -57,10 +57,10 @@ export class MalarkeyController {
   public contributors: any[];
   public malarkey: any;
 
-  private $log: ng.ILogService;
+  private $log: angular.ILogService;
   private githubContributor: GithubContributor;
 
-  constructor($log: ng.ILogService, githubContributor: GithubContributor, malarkey: any) {
+  constructor($log: angular.ILogService, githubContributor: GithubContributor, malarkey: any) {
     this.contributors = [];
 
     this.$log = $log;

--- a/generators/app/templates/src/app/components/navbar/_navbar.directive.spec.ts
+++ b/generators/app/templates/src/app/components/navbar/_navbar.directive.spec.ts
@@ -6,13 +6,13 @@ import { NavbarController } from './navbar.directive';
  * Test should check if MomentJS have been called
  */
 describe('directive navbar', function() {
-  let element: ng.IAugmentedJQuery;
+  let element: angular.IAugmentedJQuery;
   let navbarController: NavbarController;
   let timeInMs: number;
 
   beforeEach(angular.mock.module('<%- appName %>'));
 
-  beforeEach(inject(($compile: ng.ICompileService, $rootScope: ng.IRootScopeService) => {
+  beforeEach(inject(($compile: angular.ICompileService, $rootScope: angular.IRootScopeService) => {
     const currentDate: Date = new Date();
     timeInMs = currentDate.setHours(currentDate.getHours() - 24);
 

--- a/generators/app/templates/src/app/components/navbar/_navbar.directive.ts
+++ b/generators/app/templates/src/app/components/navbar/_navbar.directive.ts
@@ -1,5 +1,5 @@
 /** @ngInject */
-export function acmeNavbar(): ng.IDirective {
+export function acmeNavbar(): angular.IDirective {
 
   return {
     restrict: 'E',

--- a/generators/app/templates/src/app/main/_main.controller.spec.ts
+++ b/generators/app/templates/src/app/main/_main.controller.spec.ts
@@ -6,7 +6,7 @@ describe('controllers', () => {
 
   beforeEach(angular.mock.module('<%- appName %>'));
 
-  beforeEach(inject(($controller: ng.IControllerService, webDevTec: WebDevTecService, toastr: any) => {
+  beforeEach(inject(($controller: angular.IControllerService, webDevTec: WebDevTecService, toastr: any) => {
     webDevTec.data = [null, null, null, null, null];
     spyOn(toastr, 'info').and.callThrough();
 
@@ -17,7 +17,7 @@ describe('controllers', () => {
     expect(mainController.creationDate > 0).toBeTruthy();
   });
 
-  it('should define animate class after delaying timeout ', inject(($timeout: ng.ITimeoutService) => {
+  it('should define animate class after delaying timeout ', inject(($timeout: angular.ITimeoutService) => {
     $timeout.flush();
     expect(mainController.classAnimation).toEqual('rubberBand');
   }));

--- a/generators/app/templates/src/app/main/_main.controller.ts
+++ b/generators/app/templates/src/app/main/_main.controller.ts
@@ -8,7 +8,7 @@ export class MainController {
   public toastr: any;
 
   /* @ngInject */
-  constructor ($timeout: ng.ITimeoutService, webDevTec: WebDevTecService, toastr: any) {
+  constructor ($timeout: angular.ITimeoutService, webDevTec: WebDevTecService, toastr: any) {
     this.awesomeThings = new Array();
     this.webDevTec = webDevTec;
     this.classAnimation = '';
@@ -18,7 +18,7 @@ export class MainController {
   }
 
   /** @ngInject */
-  activate($timeout: ng.ITimeoutService) {
+  activate($timeout: angular.ITimeoutService) {
     this.getWebDevTec();
 
     var self = this;

--- a/generators/app/templates/tslint.json
+++ b/generators/app/templates/tslint.json
@@ -34,7 +34,7 @@
       "trace"
     ],
     "no-construct": true,
-    "no-constructor-vars": true,
+    "no-constructor-vars": false,
     "no-debugger": true,
     "no-duplicate-key": true,
     "no-duplicate-variable": true,


### PR DESCRIPTION
Two little changes. 
First in Visual Studio Code although having installed angular typings using tsd it refused to recognise ng.* declarations. Looking through the actual d.ts file, I noticed that ng is an alias for angular.
```
declare var angular: angular.IAngularStatic;
// Collapse angular into ng
import ng = angular;
```
Replacing ng.* with angular.* fixed the issue and Visual Studio, WebStorm and Atom are all happy with it. Not sure why it is not picking it up, bug angular.* seems more correct anyway (apart from the extra space it takes).

Secondly, typescript has a nice shorthand for declaring class properties for constructor parameters which cleans up the code a bit (produced js is identical) and thought it would nice to use them in your templates.

