### PR TITLE
Upgrade from Babel 5 to Babel 6

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -53,9 +53,9 @@
 <% } if (props.jsPreprocessor.srcExtension === 'es6') { -%>
     "eslint-loader": "~1.1.0",
 <% } if (props.jsPreprocessor.key === 'babel') { -%>
-    "babel-core": "~6.0.20",
+    "babel-core": "~6.1.2",
     "babel-loader": "~6.0.1",
-    "babel-preset-es2015": "~6.0.15",
+    "babel-preset-es2015": "~6.1.2",
 <% } if (props.jsPreprocessor.key === 'traceur') { -%>
     "traceur-loader": "~0.6.3",
 <% } if (props.jsPreprocessor.key === 'typescript') { -%>

--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -53,8 +53,9 @@
 <% } if (props.jsPreprocessor.srcExtension === 'es6') { -%>
     "eslint-loader": "~1.1.0",
 <% } if (props.jsPreprocessor.key === 'babel') { -%>
-    "babel-core": "~5.8.25",
-    "babel-loader": "~5.3.2",
+    "babel-core": "~6.0.20",
+    "babel-loader": "~6.0.1",
+    "babel-preset-es2015": "~6.0.15",
 <% } if (props.jsPreprocessor.key === 'traceur') { -%>
     "traceur-loader": "~0.6.3",
 <% } if (props.jsPreprocessor.key === 'typescript') { -%>

--- a/generators/app/templates/gulp/_scripts.js
+++ b/generators/app/templates/gulp/_scripts.js
@@ -44,7 +44,7 @@ function webpackWrapper(watch, test, callback) {
       preLoaders: [{ test: /\.ts$/, exclude: /node_modules/, loader: 'tslint-loader'}],
 <%   } -%>
 <%   if (props.jsPreprocessor.key === 'babel') { -%>
-      loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'babel-loader?presets[]=es2015']}]
+      loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'babel?presets[]=es2015']}]
 <%   } if (props.jsPreprocessor.key === 'traceur') { -%>
       loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'traceur-loader']}]
 <%   } if (props.jsPreprocessor.key === 'typescript') { -%>

--- a/generators/app/templates/gulp/_scripts.js
+++ b/generators/app/templates/gulp/_scripts.js
@@ -44,7 +44,7 @@ function webpackWrapper(watch, test, callback) {
       preLoaders: [{ test: /\.ts$/, exclude: /node_modules/, loader: 'tslint-loader'}],
 <%   } -%>
 <%   if (props.jsPreprocessor.key === 'babel') { -%>
-      loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'babel-loader']}]
+      loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'babel-loader?presets[]=es2015']}]
 <%   } if (props.jsPreprocessor.key === 'traceur') { -%>
       loaders: [{ test: /\.js$/, exclude: /node_modules/, loaders: ['ng-annotate', 'traceur-loader']}]
 <%   } if (props.jsPreprocessor.key === 'typescript') { -%>

--- a/test/template/test-scripts.js
+++ b/test/template/test-scripts.js
@@ -56,7 +56,7 @@ describe('gulp-angular scripts template', function () {
     model.props.jsPreprocessor.srcExtension = 'es6';
     result = scripts(model);
     result.should.match(/function webpackWrapper\(watch, test, callback\)/);
-    result.should.match(/loaders:.*loaders: \['ng-annotate', 'babel-loader\?presets\[\]\=es2015'/);
+    result.should.match(/loaders:.*loaders: \['ng-annotate', 'babel\?presets\[\]\=es2015'/);
     result.should.match(/gulp\.task\('scripts:watch'/);
     result.should.not.match(/traceur/);
     result.should.not.match(/coffee/);

--- a/test/template/test-scripts.js
+++ b/test/template/test-scripts.js
@@ -56,7 +56,7 @@ describe('gulp-angular scripts template', function () {
     model.props.jsPreprocessor.srcExtension = 'es6';
     result = scripts(model);
     result.should.match(/function webpackWrapper\(watch, test, callback\)/);
-    result.should.match(/loaders:.*loaders: \['ng-annotate', 'babel-loader'/);
+    result.should.match(/loaders:.*loaders: \['ng-annotate', 'babel-loader\?presets\[\]\=es2015'/);
     result.should.match(/gulp\.task\('scripts:watch'/);
     result.should.not.match(/traceur/);
     result.should.not.match(/coffee/);


### PR DESCRIPTION
As Babel is upgrading from version 5 to version 6, some small changes had to be made to allow the app to compile correctly. 

I just follow the official [migration guide](https://medium.com/@malyw/how-to-update-babel-5-x-6-x-d828c230ec53#.yqxukuzdk).