### PR TITLE
deprecated option proxyHost was replaced with changeOrigin parameter

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -35,7 +35,7 @@ The generator is shipped with the awesome [Browser Sync](http://www.browsersync.
 The recommended development process is to serve your web resources locally to be more reactive and be able to have features like automatic reload of your page when you make a modification.
 
 If you have a backend server to address, keep the development server and either:
-  - launch your request with complete URLs (but you'll have to handle [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing)) 
+  - launch your request with complete URLs (but you'll have to handle [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing))
   - or you can use the embedded proxy feature which can redirect your request from the development server to your backend transparently without dealing with CORS.
 
 ### Serve you `src` folder
@@ -64,7 +64,7 @@ At this point, your application will have to launch requests both to request sta
 
 The cleaner way to address this need is to add a proxy feature to the Browser Sync server. This feature is inactive by default as we can't know about your backend configuration, but it's in the comments and easy to start. Look in `gulp/serve.js`, you've got a line in the comments:
 ```javascript
-server.middleware = proxyMiddleware('/users', {target: 'http://jsonplaceholder.typicode.com', proxyHost: 'jsonplaceholder.typicode.com'});
+server.middleware = proxyMiddleware('/users', {target: 'http://jsonplaceholder.typicode.com', changeOrigin: true});
 ```
 
 Replace the parameters with your needs, relaunch the server, and you should be able to target your backend through Browser Sync's domain and port.

--- a/generators/app/templates/gulp/_server.js
+++ b/generators/app/templates/gulp/_server.js
@@ -35,9 +35,9 @@ function browserSyncInit(baseDir, browser) {
    * You just have to configure a context which will we redirected and the target url.
    * Example: $http.get('/users') requests will be automatically proxified.
    *
-   * For more details and option, https://github.com/chimurai/http-proxy-middleware/blob/v0.0.5/README.md
+   * For more details and option, https://github.com/chimurai/http-proxy-middleware/blob/v0.9.0/README.md
    */
-  // server.middleware = proxyMiddleware('/users', {target: 'http://jsonplaceholder.typicode.com', proxyHost: 'jsonplaceholder.typicode.com'});
+  // server.middleware = proxyMiddleware('/users', {target: 'http://jsonplaceholder.typicode.com', changeOrigin: true});
 
   browserSync.instance = browserSync.init({
     startPath: '/',


### PR DESCRIPTION
`generator-gulp-angular` has dependency to  `~0.9.0` of `http-proxy-middleware`.

When you remove comments from the proxy configuration line in `gulp/server.js` of generated project and run it; you would get a warning:

```
*************************************
[HPM] Deprecated "option.proxyHost"
      Use "option.changeOrigin" or "option.headers.host" instead
      "option.proxyHost" will be removed in future release.
*************************************
```

So `proxyHost` option has changed to `proxyHost` flag as suggested. Also see [http-proxy-middleware v0.9.0 README.md](https://github.com/chimurai/http-proxy-middleware/blob/v0.9.0/README.md):

> * (DEPRECATED) **option.proxyHost**: Use `option.changeOrigin = true` instead.