### PR TITLE
Fix for bug #660 (index.html file is incorrectly reloaded)

### DIFF
--- a/generators/app/templates/gulp/_inject.js
+++ b/generators/app/templates/gulp/_inject.js
@@ -9,6 +9,10 @@ var $ = require('gulp-load-plugins')();
 var wiredep = require('wiredep').stream;
 var _ = require('lodash');
 
+gulp.task('inject-reload', ['inject'], function() {
+  browserSync.reload();
+});
+
 <% if (props.cssPreprocessor.key !== 'noCssPrepro') { -%>
 gulp.task('inject', ['scripts', 'styles'], function () {
   var injectStyles = gulp.src([

--- a/generators/app/templates/gulp/_scripts.js
+++ b/generators/app/templates/gulp/_scripts.js
@@ -11,6 +11,10 @@ var webpack = require('webpack-stream');
 
 var $ = require('gulp-load-plugins')();
 
+gulp.task('scripts-reload', ['scripts'], function() {
+  browserSync.reload();
+});
+
 <% if (props.jsPreprocessor.srcExtension !== 'es6' && props.jsPreprocessor.key !== 'typescript') { -%>
 gulp.task('scripts', function () {
   return gulp.src(path.join(conf.paths.src, '/app/**/*.<%- props.jsPreprocessor.extension %>'))
@@ -27,7 +31,6 @@ gulp.task('scripts', function () {
     .pipe($.sourcemaps.write())
     .pipe(gulp.dest(path.join(conf.paths.tmp, '/serve/app')))
 <%   } -%>
-    .pipe(browserSync.reload({ stream: true }))
     .pipe($.size())
 });
 <% } else { -%>

--- a/generators/app/templates/gulp/_styles.js
+++ b/generators/app/templates/gulp/_styles.js
@@ -11,6 +11,10 @@ var $ = require('gulp-load-plugins')();
 var wiredep = require('wiredep').stream;
 var _ = require('lodash');
 
+gulp.task('styles-reload', ['styles'], function() {
+  browserSync.reload();
+});
+
 gulp.task('styles', function () {
 <% if (props.cssPreprocessor.key === 'less') { -%>
   var lessOptions = {
@@ -67,6 +71,5 @@ gulp.task('styles', function () {
 <% if (props.cssPreprocessor.key === 'ruby-sass') { -%>
     .pipe(cssFilter.restore)
 <% } -%>
-    .pipe(gulp.dest(path.join(conf.paths.tmp, '/serve/app/')))
-    .pipe(browserSync.reload({ stream: true }));
+    .pipe(gulp.dest(path.join(conf.paths.tmp, '/serve/app/')));
 });

--- a/generators/app/templates/gulp/_watch.js
+++ b/generators/app/templates/gulp/_watch.js
@@ -12,7 +12,7 @@ function isOnlyChange(event) {
 
 gulp.task('watch', [<%- watchTaskDeps.join(', ') %>], function () {
 
-  gulp.watch([path.join(conf.paths.src, '/*.html'), 'bower.json'], ['inject']);
+  gulp.watch([path.join(conf.paths.src, '/*.html'), 'bower.json'], ['inject-reload']);
 
 <% if (props.cssPreprocessor.extension === 'css') { -%>
   gulp.watch(path.join(conf.paths.src, '/app/**/*.css'), function(event) {
@@ -26,10 +26,10 @@ gulp.task('watch', [<%- watchTaskDeps.join(', ') %>], function () {
 <% if (props.cssPreprocessor.key === 'noCssPrepro') { -%>
       browserSync.reload(event.path);
 <% } else { -%>
-      gulp.start('styles');
+      gulp.start('styles-reload');
 <% } -%>
     } else {
-      gulp.start('inject');
+      gulp.start('inject-reload');
     }
   });
 
@@ -43,9 +43,9 @@ gulp.task('watch', [<%- watchTaskDeps.join(', ') %>], function () {
   ], function(event) {
 <%   } -%>
     if(isOnlyChange(event)) {
-      gulp.start('scripts');
+      gulp.start('scripts-reload');
     } else {
-      gulp.start('inject');
+      gulp.start('inject-reload');
     }
   });
 <% } -%>

--- a/test/template/test-watch.js
+++ b/test/template/test-watch.js
@@ -56,14 +56,14 @@ describe('gulp-angular watch template', function () {
     model.props.jsPreprocessor.srcExtension = 'notes6';
     result = watch(model);
     result.should.match(/gulp\.watch\(\[\n.*\.js'.*\n.*\.notjs'.*\n.*\],/);
-    result.should.match(/gulp\.start\('scripts'\);/);
+    result.should.match(/gulp\.start\('scripts-reload'\);/);
 
     model.props.jsPreprocessor.key = 'notnone';
     model.props.jsPreprocessor.extension = 'notjs';
     model.props.jsPreprocessor.srcExtension = 'es6';
     result = watch(model);
     result.should.not.match(/gulp\.watch\(\[\n.*\.js'.*\n.*\.notjs'.*\n.*\],/);
-    result.should.not.match(/gulp\.start\('scripts'\);/);
+    result.should.not.match(/gulp\.start\('scripts-reload'\);/);
   });
 
   it('should watch the html preprocessor extension files', function () {

--- a/test/template/test-watch.js
+++ b/test/template/test-watch.js
@@ -40,7 +40,7 @@ describe('gulp-angular watch template', function () {
     model.props.cssPreprocessor.extension = 'notcss';
     result = watch(model);
     result.should.match(/gulp\.watch\(\[\n.*\.css'.*\n.*\.notcss'.*\n.*\],/);
-    result.should.match(/gulp\.start\('styles'\);/);
+    result.should.match(/gulp\.start\('styles-reload'\);/);
   });
 
   it('should watch the js preprocessor extension files', function () {
@@ -49,7 +49,7 @@ describe('gulp-angular watch template', function () {
     model.props.jsPreprocessor.srcExtension = 'notes6';
     var result = watch(model);
     result.should.match(/gulp\.watch\(.*\*\.js'/);
-    result.should.match(/gulp\.start\('scripts'\);/);
+    result.should.match(/gulp\.start\('scripts-reload'\);/);
 
     model.props.jsPreprocessor.key = 'notnone';
     model.props.jsPreprocessor.extension = 'notjs';


### PR DESCRIPTION
Separated logic of reload and compilation for Gulp 3.x allowing to make proper reload for index.html and other assets.
Fix for bug #660 