### PR TITLE
Exclude node_modules and bower_components in tsconfig.json

### DIFF
--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -2,5 +2,9 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs"
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "bower_components"
+  ]
 }


### PR DESCRIPTION
This section is needed, because otherwise some tools will scan every subfolder of `node_modules` and `bower_component`, and this takes a very long time.