### PR TITLE
Update Angular and Angular Bootstrap

### DIFF
--- a/generators/app/prompts.json
+++ b/generators/app/prompts.json
@@ -5,11 +5,11 @@
     "message": "Which version of Angular do you want?",
     "choices": [
       {
-        "value": "~1.4.2",
+        "value": "1.4.*",
         "name": "1.4.x (stable)"
       },
       {
-        "value": "~1.3.16",
+        "value": "1.3.*",
         "name": "1.3.x (legacy)"
       }
     ]

--- a/generators/app/prompts.json
+++ b/generators/app/prompts.json
@@ -5,11 +5,11 @@
     "message": "Which version of Angular do you want?",
     "choices": [
       {
-        "value": "1.4.*",
+        "value": "~1.4.8",
         "name": "1.4.x (stable)"
       },
       {
-        "value": "1.3.*",
+        "value": "~1.3.20",
         "name": "1.3.x (legacy)"
       }
     ]

--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -49,7 +49,7 @@
     "material-design-lite": "~1.0.4",
     "material-design-iconfont": "~0.0.2",
 <% } if(props.bootstrapComponents.key === 'ui-bootstrap') { -%>
-    "angular-bootstrap": "~0.13.4",
+    "angular-bootstrap": "~0.14.3",
 <% } if(props.bootstrapComponents.key === 'angular-strap') { -%>
     "angular-strap": "~2.3.1",
 <% } if(props.foundationComponents.key === 'angular-foundation') { -%>


### PR DESCRIPTION
1. I set the Angular dependencies to use asterisks instead of tildes. The tildes specify "close to" in the patch range. For example, if 1.2.5, 1.4.2, 1.4.3, 1.4.8, and 1.5.6 are available and is it looking for `~1.4.2`, then it will choose 1.4.2, **not 1.4.8.** If 1.4.2 was not available, then it would have chosen 1.4.3. The asterisk tells it to choose the most update to date. So, `1.4.*` would match 1.4.8. The patch area of SemVer describes bugfixes and patches, so it should be safe to upgrade automatically.
2. I updated Angular Bootstrap. All of the [prefixes changed in 0.14](https://github.com/angular-ui/bootstrap/wiki/Migration-guide-for-prefixes), but that shouldn't affect the example pages. This should dismiss confusion with the docs. The docs include these prefixes, but the generator does not.

I didn't add asterisks to everything because I figured that someone wouldn't like that. I can add another commit if needed though.