### PR TITLE
Fix malarkey.directive.ts change private to public

### DIFF
--- a/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
+++ b/generators/app/templates/src/app/components/malarkey/_malarkey.directive.ts
@@ -57,7 +57,7 @@ export class MalarkeyController {
   public contributors: any[];
 
 
-  constructor(private $log: angular.ILogService, private githubContributor: GithubContributor, private malarkey: any) {
+  constructor(private $log: angular.ILogService, private githubContributor: GithubContributor, public malarkey: any) {
     this.contributors = [];
 
     this.activate();


### PR DESCRIPTION
Fix this error :

```
ERROR in [default] myApp/src/app/components/malarkey/malarkey.directive.ts:25:18
Property 'malarkey' does not exist on type 'MalarkeyController'.
```
There is an access to the malarkey property of the MalarkeyController class in the linkFunc of the directive.