### PR TITLE
Add mobile collapsed menu for bootstrap

### DIFF
--- a/generators/app/templates/src/app/components/navbar/__bootstrap-navbar.html
+++ b/generators/app/templates/src/app/components/navbar/__bootstrap-navbar.html
@@ -1,6 +1,12 @@
 <nav class="navbar navbar-static-top navbar-inverse">
   <div class="container-fluid">
     <div class="navbar-header">
+      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#bs-example-navbar-collapse-6" aria-expanded="false">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
       <a class="navbar-brand" href="https://github.com/Swiip/generator-gulp-angular">
         <span class="glyphicon glyphicon-home"></span> Gulp Angular
       </a>


### PR DESCRIPTION
To use the mobile menu you need the default button.  I think it would be really helpful to have it built into the bootstrap options.  Thanks for the generator!