### PR TITLE
Less urls

### DIFF
--- a/generators/app/templates/gulp/_styles.js
+++ b/generators/app/templates/gulp/_styles.js
@@ -23,7 +23,7 @@ gulp.task('styles', function() {
 var buildStyles = function() {
 <% if (props.cssPreprocessor.key === 'less') { -%>
   var lessOptions = {
-    options: [
+    paths: [
       'bower_components',
       path.join(conf.paths.src, '/app')
     ]

--- a/generators/app/templates/gulp/_styles.js
+++ b/generators/app/templates/gulp/_styles.js
@@ -26,7 +26,8 @@ var buildStyles = function() {
     paths: [
       'bower_components',
       path.join(conf.paths.src, '/app')
-    ]
+    ],
+    relativeUrls : true
   };
 <% } if (props.cssPreprocessor.extension === 'scss') { -%>
   var sassOptions = {


### PR DESCRIPTION
I have experienced issues with css `url(...)` when using less with files placed in subdirectories of my project.

By default, less compiler keep untouched paths of `url(...)` when importing a external file (@import). 

Less [relativeUrls](http://lesscss.org/usage/#using-less-in-the-browser-relativeurls) option allows to fix urls based on relative path of imported path .

I've also replaced the options key by `paths`, as it seems to be the option you've tried to set ... I'm not sure it's really usefull though, because things was working properly with the wrong key name, maybe it could be removed.