### PR TITLE
Add protractor:dev target for easy e2e development

### DIFF
--- a/generators/app/templates/gulp/e2e-tests.js
+++ b/generators/app/templates/gulp/e2e-tests.js
@@ -36,3 +36,4 @@ function runProtractor (done) {
 gulp.task('protractor', ['protractor:src']);
 gulp.task('protractor:src', ['serve:e2e', 'webdriver-update'], runProtractor);
 gulp.task('protractor:dist', ['serve:e2e-dist', 'webdriver-update'], runProtractor);
+gulp.task('protractor:dev', [], runProtractor); // Runs e2e tests on a running 'gulp serve:e2e' instance


### PR DESCRIPTION
The standard protractor task is way too slow for development of e2e tests, as it spawns a new instance of gulp serve:e2e every time it is run. During development, you probably have an instance of gulp serve running already.