### PR TITLE
Fix typo

### DIFF
--- a/generators/app/templates/gulp/_styles.js
+++ b/generators/app/templates/gulp/_styles.js
@@ -23,7 +23,7 @@ gulp.task('styles', function() {
 var buildStyles = function() {
 <% if (props.cssPreprocessor.key === 'less') { -%>
   var lessOptions = {
-    options: [
+    paths: [
       'bower_components',
       path.join(conf.paths.src, '/app')
     ]


### PR DESCRIPTION
Rename 'options' to 'paths' to match available less options (closes #1041)