### PR TITLE
Update sassOptions to reflect correct style property.

### DIFF
--- a/generators/app/templates/gulp/_styles.js
+++ b/generators/app/templates/gulp/_styles.js
@@ -31,7 +31,7 @@ var buildStyles = function() {
   };
 <% } if (props.cssPreprocessor.extension === 'scss') { -%>
   var sassOptions = {
-    style: 'expanded',
+    outputStyle: 'expanded',
     precision: 10
   };
 <% } -%>


### PR DESCRIPTION
This is a fresh PR replacing #876

I noticed the style value was being ignored in sassOptions, this is because gulp-sass via node-sass uses `outputStyle` as the output-style property. Updated here.

See https://github.com/sass/node-sass#outputstyle.