### PR TITLE
Add Browsersync options to scripts task

### DIFF
--- a/generators/app/templates/gulp/_scripts.js
+++ b/generators/app/templates/gulp/_scripts.js
@@ -14,8 +14,14 @@ var $ = require('gulp-load-plugins')();
 
 <% if (props.jsPreprocessor.srcExtension !== 'es6' && props.jsPreprocessor.key !== 'typescript') { -%>
 gulp.task('scripts-reload', function() {
+  var bsOptions = {once: true};
+<%   if (props.jsPreprocessor.key === 'noJsPrepro') { -%>
+  if (conf._gulpWatchEvent) {
+    bsOptions.match = conf._gulpWatchEvent.path;
+  }
+<%   } -%>
   return buildScripts()
-    .pipe(browserSync.stream());
+    .pipe(browserSync.stream(bsOptions));
 });
 
 gulp.task('scripts', function() {

--- a/generators/app/templates/gulp/_watch.js
+++ b/generators/app/templates/gulp/_watch.js
@@ -42,11 +42,13 @@ gulp.task('watch', [<%- watchTaskDeps.join(', ') %>], function () {
     path.join(conf.paths.src, '/app/**/*.<%- props.jsPreprocessor.extension %>')
   ], function(event) {
 <%   } -%>
+    conf._gulpWatchEvent = event;
     if(isOnlyChange(event)) {
       gulp.start('scripts-reload');
     } else {
       gulp.start('inject-reload');
     }
+    delete conf._gulpWatchEvent;
   });
 <% } -%>
 

--- a/test/template/test-scripts.js
+++ b/test/template/test-scripts.js
@@ -74,4 +74,16 @@ describe('gulp-angular scripts template', function () {
     result.should.not.match(/typescript/);
   });
 
+  it('should add match to browserSync options when not using a js preprocessor', function () {
+    model.props.jsPreprocessor.key = 'noJsPrepro';
+    var result = scripts(model);
+    result.should.match(/bsOptions\.match/);
+  });
+
+  it('should not add match to browserSync options when using a js preprocessor', function () {
+    model.props.jsPreprocessor.key = 'babel';
+    var result = scripts(model);
+    result.should.not.match(/bsOptions\.match/);
+  });
+
 });


### PR DESCRIPTION
Right now, when not using a js preprocessor, the page is refreshed multiple times in a short time.
I'm using Django on the backend and the local server hangs for a long time because of the multiple reloads (its faster to kill it and restart it). This is very noticeable when there are more than 30 js files.

This PR would fix this problem and possibly #1067.

A filter is also provided to only reload the changed script and stop unwanted files from being reloaded. I did this so that I can inject a controller instead of refreshing the browser. The way I pass the changed file is a little ugly, so if you want I can exclude it from the PR.