### PR TITLE
removed deprecated wrench and replaces it with nodes fs

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -96,8 +96,7 @@
 <% if (qrCode) { -%>
     "qrcode-terminal": "~0.10.0",
 <% } -%>
-    "uglify-save-license": "~0.4.1",
-    "wrench": "~1.5.8"
+    "uglify-save-license": "~0.4.1"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -6,14 +6,14 @@
 
 'use strict';
 
+var fs = require('fs');
 var gulp = require('gulp');
-var wrench = require('wrench');
 
 /**
  *  This will load all js or coffee files in the gulp directory
  *  in order to load all gulp tasks
  */
-wrench.readdirSyncRecursive('./gulp').filter(function(file) {
+fs.readdirSync('./gulp').filter(function(file) {
   return (/\.(js|coffee)$/i).test(file);
 }).map(function(file) {
   require('./gulp/' + file);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3441,11 +3441,6 @@
       "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
-    "wrench": {
-      "version": "1.5.8",
-      "from": "wrench@1.5.8",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
-    },
     "write": {
       "version": "0.2.1",
       "from": "write@>=0.2.1 <0.3.0",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,7 @@
     "mz": "~2.0.0",
     "recursive-readdir": "~1.2.1",
     "sinon": "~1.17.1",
-    "sinon-chai": "~2.8.0",
-    "wrench": "1.5.8"
+    "sinon-chai": "~2.8.0"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/test/npm-shrinkwrap.json
+++ b/test/npm-shrinkwrap.json
@@ -6890,11 +6890,6 @@
       "from": "wrappy@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
     },
-    "wrench": {
-      "version": "1.5.8",
-      "from": "wrench@>=1.5.8 <1.6.0",
-      "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.8.tgz"
-    },
     "write": {
       "version": "0.2.1",
       "from": "write@>=0.2.1 <0.3.0",


### PR DESCRIPTION
Because wrench is deprecated I replaced `wrench.readdirSyncRecursive` with `fs.readdirSync` to remove it from `package.json`.