### PR TITLE
Remove duplicate bower_components from templates

### DIFF
--- a/generators/app/templates/src/app/_bootstrap/__bootstrap-index.less
+++ b/generators/app/templates/src/app/_bootstrap/__bootstrap-index.less
@@ -10,7 +10,7 @@
  *  The list of variables are listed here bower_components/bootstrap/less/variables.less
  */
 @navbar-inverse-link-color: #5AADBB;
-@icon-font-path: '../<%- computedPaths.appToBower %>/bower_components/bootstrap/fonts/';
+@icon-font-path: '../<%- computedPaths.appToBower %>/bootstrap/fonts/';
 
 .browsehappy {
   margin: 0.2em 0;

--- a/generators/app/templates/src/app/_bootstrap/__bootstrap-index.scss
+++ b/generators/app/templates/src/app/_bootstrap/__bootstrap-index.scss
@@ -3,7 +3,7 @@
  *  The list of variables are listed here bower_components/bootstrap-sass/assets/stylesheets/bootstrap/_variables.scss
  */
 $navbar-inverse-link-color: #5AADBB;
-$icon-font-path: "../<%- computedPaths.appToBower %>/bower_components/bootstrap-sass/assets/fonts/bootstrap/";
+$icon-font-path: "../<%- computedPaths.appToBower %>/bootstrap-sass/assets/fonts/bootstrap/";
 
 /**
  *  Do not remove the comments below. It's the markers used by wiredep to inject

--- a/generators/app/templates/src/app/_bootstrap/__bootstrap-index.styl
+++ b/generators/app/templates/src/app/_bootstrap/__bootstrap-index.styl
@@ -3,7 +3,7 @@
  *  The list of variables are listed here bower_components/bootstrap-stylus/bootstrap/variables.styl
  */
 $navbar-inverse-link-color = #5AADBB
-$icon-font-path = "../<%- computedPaths.appToBower %>/bower_components/bootstrap-stylus/fonts/"
+$icon-font-path = "../<%- computedPaths.appToBower %>/bootstrap-stylus/fonts/"
 
 /**
  *  Do not remove the comments below. It's the markers used by wiredep to inject


### PR DESCRIPTION
PR is connected with this issue https://github.com/Swiip/generator-gulp-angular/issues/1095. There is problem with 404 not found for fonts (duplicate bower_components), so I removed one hardcoded "bower_components" from templates