### PR TITLE
fixed material-icon paths

### DIFF
--- a/generators/app/templates/gulp/_build.js
+++ b/generators/app/templates/gulp/_build.js
@@ -63,7 +63,7 @@ gulp.task('html', ['inject', 'partials'], function () {
 <% } else if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'styl') { -%>
     .pipe($.replace('../<%- computedPaths.appToBower %>/bower_components/bootstrap-stylus/fonts/', '../fonts/'))
 <% } else if (props.ui.key === 'material-design-lite' || props.ui.key === 'angular-material') { -%>
-    .pipe($.replace('../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/', '../fonts/'))
+    .pipe($.replace('../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/', '../fonts/'))
 <% } -%>
     .pipe($.cssnano())
     .pipe($.rev())
@@ -100,7 +100,7 @@ gulp.task('fonts', function () {
 <% if (props.ui.key === 'bootstrap' && props.cssPreprocessor.extension === 'styl') { -%>
   return gulp.src($.mainBowerFiles().concat('bower_components/bootstrap-stylus/fonts/*'))
 <% } else if (props.ui.key === 'material-design-lite' || props.ui.key === 'angular-material') { -%>
-  return gulp.src($.mainBowerFiles().concat('bower_components/material-design-iconfont/iconfont/*'))
+  return gulp.src($.mainBowerFiles().concat('bower_components/material-design-icons/iconfont/*'))
 <% } else { -%>
   return gulp.src($.mainBowerFiles())
 <% } -%>

--- a/generators/app/templates/src/app/_angular-material/__angular-material-index.css
+++ b/generators/app/templates/src/app/_angular-material/__angular-material-index.css
@@ -4,12 +4,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_angular-material/__angular-material-index.less
+++ b/generators/app/templates/src/app/_angular-material/__angular-material-index.less
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_angular-material/__angular-material-index.scss
+++ b/generators/app/templates/src/app/_angular-material/__angular-material-index.scss
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_angular-material/__angular-material-index.styl
+++ b/generators/app/templates/src/app/_angular-material/__angular-material-index.styl
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 
 .material-icons
   font-family: 'Material Icons';

--- a/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.css
+++ b/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.css
@@ -4,12 +4,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.less
+++ b/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.less
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.scss
+++ b/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.scss
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 }
 
 .material-icons {

--- a/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.styl
+++ b/generators/app/templates/src/app/_material-design-lite/__material-design-lite-index.styl
@@ -11,12 +11,12 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
+  src: url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.eot); /* For IE6-8 */
   src: local('Material Icons'),
        local('MaterialIcons-Regular'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.woff) format('woff'),
-       url(../<%- computedPaths.appToBower %>/bower_components/material-design-iconfont/iconfont/MaterialIcons-Regular.ttf) format('truetype');
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff2) format('woff2'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.woff) format('woff'),
+       url(../<%- computedPaths.appToBower %>/bower_components/material-design-icons/iconfont/MaterialIcons-Regular.ttf) format('truetype');
 
 .material-icons
   font-family: 'Material Icons';


### PR DESCRIPTION
Material icons path was incorrect and was failing to be replaced with the correct path on build.