### PR TITLE
issue #1139 fixed

### DIFF
--- a/generators/app/templates/_bower.json
+++ b/generators/app/templates/_bower.json
@@ -49,7 +49,7 @@
     "material-design-lite": "~1.0.4",
     "material-design-iconfont": "~0.0.2",
 <% } if(props.bootstrapComponents.key === 'ui-bootstrap') { -%>
-    "angular-bootstrap": "~0.14.3",
+    "angular-ui-bootstrap": "~1.3.3",
 <% } if(props.bootstrapComponents.key === 'angular-strap') { -%>
     "angular-strap": "~2.3.1",
 <% } if(props.foundationComponents.key === 'angular-foundation') { -%>

--- a/test/template/test-bower.js
+++ b/test/template/test-bower.js
@@ -165,7 +165,7 @@ describe('gulp-angular bower template', function () {
     model.props.bootstrapComponents.key = 'ui-bootstrap';
     result = bower(model);
     result.should.match(/bootstrap-sass/);
-    result.should.match(/angular-bootstrap/);
+    result.should.match(/angular-ui-bootstrap/);
     result.should.not.match(/"bootstrap"/);
     result.should.not.match(/foundation-sites/);
     result.should.not.match(/angular-material/);


### PR DESCRIPTION
Scaffolding created through generator doesn't include latest angular bootstrap ui version it still point to ~0.13.4#1139

Updated "angular-bootstrap": "~0.13.4" to "angular-ui-bootstrap": "~1.3.3"