### PR TITLE
We are un-maintaining generator-gulp-angular

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->
+
+# Allo' ! :wave:
+
+### This is just to let you know that this project is unmaintained.
+
+### For more info, please see: https://github.com/Swiip/generator-gulp-angular/pull/1155
+
+### We don't expect new issues or PRs.
+
+### But we'll happily seen you soon in the next iteration of this project: [FountainJS](http://fountainjs.io/)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->
+
+# Allo' ! :wave:
+
+### This is just to let you know that this project is unmaintained.
+
+### For more info, please see: https://github.com/Swiip/generator-gulp-angular/pull/1155
+
+### We don't expect new issues or PRs.
+
+### But we'll happily seen you soon in the next iteration of this project: [FountainJS](http://fountainjs.io/)

--- a/README.md
+++ b/README.md
@@ -1,12 +1,7 @@
-## Launching [Fountain](http://fountainjs.io/) generators beta
-
-The team is proud to present the next evolution of the Yeoman gulp-angular as a new project called [FountainJS](http://fountainjs.io/).
-
-It covers Angular 1 like today but go way farther with support for Angular 2, React, SystemJS and Webpack!
-
-Check it out right now at [http://fountainjs.io/](http://fountainjs.io/).
-
 # generator-gulp-angular ![Logo](generators/app/templates/src/assets/images/generator-gulp-angular-logo.png)
+
+[![Unmaintained](https://img.shields.io/badge/generator-unmaintained-red.svg?style=flat-square)](https://github.com/Swiip/generator-gulp-angular/pull/1155)
+[![Outdated](https://img.shields.io/badge/generator-outdated-red.svg?style=flat-square)](https://github.com/Swiip/generator-gulp-angular/pull/1155)
 
 [![Build Status](https://img.shields.io/travis/Swiip/generator-gulp-angular/master.svg?style=flat-square)](http://travis-ci.org/Swiip/generator-gulp-angular)
 [![Coverage Status](https://img.shields.io/codecov/c/github/Swiip/generator-gulp-angular.svg?style=flat-square)](http://codecov.io/github/Swiip/generator-gulp-angular?branch=master)
@@ -23,6 +18,18 @@ Check it out right now at [http://fountainjs.io/](http://fountainjs.io/).
 
 > Gulp provide fast workspace with quick feedback.
 
+# **Unmaintained**, **Outdated** ? :pensive:
+Yup, this generator works but is unmaintained and outdated [for various reasons](https://github.com/Swiip/generator-gulp-angular/pull/1155).
+
+But don't panic **the most important features and more are present** in our next iteration called [FountainJS](http://fountainjs.io/).
+
+<p align="center">
+  <a href="http://fountainjs.io/">
+    <img alt="FountainJS" src="http://fountainjs.io/assets/imgs/fountain.png" width="200">
+  </a>
+</p>
+
+A tutorial is present in the [Yeoman codelab](http://yeoman.io/codelab/). :kissing_heart:
 
 ## Usage
 


### PR DESCRIPTION
From now on, there will be these little badges in the generator-gulp-angular README:

[![Unmaintained](https://img.shields.io/badge/generator-unmaintained-red.svg?style=flat-square)](https://github.com/Swiip/generator-gulp-angular/pull/1155) [![Outdated](https://img.shields.io/badge/generator-outdated-red.svg?style=flat-square)](https://github.com/Swiip/generator-gulp-angular/pull/1155)

Also when you open new issues or PRs, the issue template will tell you it's unmaintained.

Started in 2014 (84f0926d766c89b9c359ed89f7f0d3062bb4a4b0) this generator was fun and useful while it lasted. But the Web, JavaScript and NodeJS were evolved and now practices are totally different what they were 2 years ago.

***

@Swiip I let you edit this PR. Merge it when you are ready.