### PR TITLE
The "ambientDependencies" is deprecated.

### DIFF
--- a/generators/app/templates/_typings.json
+++ b/generators/app/templates/_typings.json
@@ -1,7 +1,7 @@
 {
   "name": "<%- appName %>",
   "version": false,
-  "ambientDependencies": {
+  "globalDependencies": {
 <% if (angularModulesObject.animate) { -%>
     "angular-animate": "github:DefinitelyTyped/DefinitelyTyped/angularjs/angular-animate.d.ts#bb051830df88f5a55dcf06b7fe85bf6b62cc97f2",
 <% } if (angularModulesObject.cookies) { -%>


### PR DESCRIPTION
In the new version is not posible to install the typing as the old version: `typings install --ambient --save`

We can only use `--global`, which means, the typing will look in the `globalDependencies `attribute.

If sameone is having same king of problem to install the typescript, you can do this manually